### PR TITLE
fix: Casing of method "getMetadata"

### DIFF
--- a/fabric-shim/lib/contract-spi/meta.js
+++ b/fabric-shim/lib/contract-spi/meta.js
@@ -23,7 +23,7 @@ class Meta extends Contract {
      * Gets meta data associated with this Chaincode deployment
      */
 	getContractMetaData(){
-		return Buffer.from(JSON.stringify(this.getMetaData()));
+		return Buffer.from(JSON.stringify(this.getMetadata()));
 	}
 
 }


### PR DESCRIPTION
The method in the contract base class is called `getMetadata`, not `getMetaData`.