### PR TITLE
AzurePipeline Docs error

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -89,20 +89,6 @@ stages:
                 testResultsFiles: '**/test-results.xml'
                 artifactName: 'FV Test results'
                 testRunTitle: 'FV Test results'                      
-        - job: apidocs
-          steps:
-            - task: NodeTool@0
-              inputs:
-                versionSpec: '8.x' 
-            - script: |
-                npm install
-                npm install -g gulp-cli
-              displayName: 'Setup the node environment'            
-            - script: |
-                gulp docs
-              displayName: 'Produce API docs'
-            - publish: $(System.DefaultWorkingDirectory)/docs/gen/
-              artifact: 'jsdocs'
     - stage: Publish_tag
       condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
       jobs:


### PR DESCRIPTION
Remove the API docs stage; this is a hangover from release-1.4

Change-Id: I632a219df2c1eb9534bb2c996954c4a29edf9125
Signed-off-by: Matthew B. White <whitemat@uk.ibm.com>