### PR TITLE
Add in capture of docker logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ common/temp/**
 
 package-deps.json
 test-results.xml
+docker.log

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -123,7 +123,7 @@ stages:
               inputs:
                 pathToPublish:  $(Build.ArtifactStagingDirectory)/fabric-nodeenv.tar.gz
                 artifactName: nodeenv-docker-image        
-        
+    
         # Run the FV tests but using the built material        
         - job: fvt
           displayName: 'FV Tests'
@@ -175,7 +175,11 @@ stages:
               inputs:
                 pathToPublish:  $(Build.ArtifactStagingDirectory)/testlogs
                 artifactName: 'Test logs'           
-
+            - task: PublishBuildArtifacts@1
+              condition: or(succeeded(), failed())   # publish either way    
+              inputs:
+                pathToPublish: tools/toolchain/network/docker-compose/logs/docker.log
+                artifactName: nodeenv-docker-image    
     # Publish tag for the Merge build of a regular PRi.e. w
     - stage: Publish_tag
       condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))

--- a/tools/toolchain/fabric.js
+++ b/tools/toolchain/fabric.js
@@ -161,7 +161,9 @@ const _start_docker = async () => {
 
     await runcmds([
         // make sure that necessary containers are up by docker-compose
-        util.format('docker-compose -f %s -p node up -d', fs.realpathSync(path.join(dockerComposeDir, composeFile)))
+        util.format('docker-compose -f %s -p node up -d', fs.realpathSync(path.join(dockerComposeDir, composeFile))),
+        "docker exec -d logging sh -c 'wget -q -O /logs/docker.log http://127.0.0.1:80/logs'"
+
     ]);
 };
 

--- a/tools/toolchain/network/docker-compose/docker-compose.yaml
+++ b/tools/toolchain/network/docker-compose/docker-compose.yaml
@@ -140,3 +140,12 @@ services:
       - /var/run/:/host/var/run/
     depends_on:
       - peer0.org2.example.com
+      
+  logging:
+    container_name: logging
+    image: gliderlabs/logspout
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./logs:/logs
+    ports:
+    - 17056:80         


### PR DESCRIPTION
Use logspout to capture the logs of all containers
and write to a file.

This can then be added to the Azure build report

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>
Change-Id: I056755e975e6b391924330935488f7dd85934710