### PR TITLE
Add npm login to publish step

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -183,6 +183,8 @@ stages:
                 workingFile: '$(Agent.TempDirectory)/.npmrc'
                 customEndpoint: 'fabric-chainode-node-npm' 
             - script: |
+                npm config ls
+                npm login
                 # Add or delete modules from here..
                 for module in fabric-shim fabric-shim-crypto fabric-contract-api; do
                     if [ -d "$module" ]; then


### PR DESCRIPTION
Build failed with 401 error, "You must be logged in to publish packages."

Adding `npm config ls` to check the correct user config is being picked up and trying an `npm login` to see if that helps.

Signed-off-by: James Taylor <jamest@uk.ibm.com>