### PR TITLE
[FABCN-378] Update gh-pages

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -214,7 +214,7 @@ stages:
                 sourceFolder: '$(Build.SourcesDirectory)/docs'
                 targetFolder: $(Build.ArtifactStagingDirectory)/jsdoc
                 cleanTargetFolder: true
-              displayName: 'Copy jsdoc'
+              displayName: 'Copy JSDoc'
             - task: CopyFiles@2
               condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
               inputs:

--- a/docs/404.md
+++ b/docs/404.md
@@ -5,6 +5,6 @@ permalink: /404.html
 
 ## The page you wanted does not exist
 
-If you were looking for Javadoc, try one of the releases below:
+If you were looking for JSDoc, try one of the releases below:
 
 {% include apidocs.html %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Hyperledger Fabric offers a number of SDKs to support developing smart contracts
 in various programming languages. There are two other smart contract SDKs available for Java, and Go, in addition to this Node.js SDK:
 
   * [Java SDK documentation](https://hyperledger.github.io/fabric-chaincode-java/)
-  * [Go SDK documentation](https://godoc.org/github.com/hyperledger/fabric/core/chaincode/shim)
+  * [Go SDK documentation](https://godoc.org/github.com/hyperledger/fabric-chaincode-go)
 
 ## Documentation
 


### PR DESCRIPTION
- fixed 404 page (should be JSDoc, not Javadoc)
- fixed Go SDK link

Signed-off-by: James Taylor <jamest@uk.ibm.com>