### PR TITLE
Update audit level

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -192,7 +192,7 @@ stages:
                 node common/scripts/install-run-rush.js start-verdaccio # script will check for the ci variable and use built images
                 mkdir -p $(Build.SourcesDirectory)/audit && cd $(Build.SourcesDirectory)/audit && npm init -y
                 npm install --registry http://localhost:4873 fabric-shim fabric-shim-crypto fabric-shim-api fabric-contract-api --save
-                npm audit
+                npm audit --audit-level=moderate
               displayName: 'Run npm audit'
 
         # Build and publish API docs on every merge build


### PR DESCRIPTION
Temporarily raise audit level to moderate to work around current minimist audit failures

Can be reverted after grpc, rc, and tar dependecies have been updated to pull in updated versions of mkdirp and minimist

Signed-off-by: James Taylor <jamest@uk.ibm.com>