### PR TITLE
Cherry pick to master: Update audit level & Update fabric docker image version number pull

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -195,7 +195,7 @@ stages:
                 node common/scripts/install-run-rush.js start-verdaccio # script will check for the ci variable and use built images
                 mkdir -p $(Build.SourcesDirectory)/audit && cd $(Build.SourcesDirectory)/audit && npm init -y
                 npm install --registry http://localhost:4873 fabric-shim fabric-shim-crypto fabric-shim-api fabric-contract-api --save
-                npm audit
+                npm audit --audit-level=moderate
               displayName: 'Run npm audit'
 
         # Build and publish API docs on every merge build

--- a/tools/getEdgeDocker.sh
+++ b/tools/getEdgeDocker.sh
@@ -10,8 +10,8 @@ echo "Fetching images from Artifactory"
 ARTIFACTORY_URL=hyperledger-fabric.jfrog.io
 ORG_NAME="hyperledger"
 
-VERSION=2.0.0
-CA_VERSION=1.4.4
+VERSION=2.1
+CA_VERSION=1.4
 ARCH="amd64"
 MASTER_TAG=$ARCH-master
 


### PR DESCRIPTION
Temporarily raise audit level to moderate to work around current minimist audit failures

Can be reverted after grpc, rc, and tar dependecies have been updated to pull in updated versions of mkdirp and minimist

Signed-off-by: James Taylor <jamest@uk.ibm.com>