### PR TITLE
[FABCN-391] Update apidoc site header

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,4 +3,4 @@ title: "fabric-chaincode-node"
 releases:
   - master
   - release-1.4
-  - release-2.x
+  - release-2.0

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -3,25 +3,20 @@
     <div class="wrapper">
       <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
   
-      {%- assign num_releases = site.releases | size -%}
-      {%- if num_releases > 0 -%}
-        <nav class="site-nav">
-          <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-          <label for="nav-trigger">
-            <span class="menu-icon">
-              <svg viewBox="0 0 18 15" width="18px" height="15px">
-                <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
-              </svg>
-            </span>
-          </label>
-  
-          <div class="trigger">
-            {%- for release in site.releases -%}
-              <a class="page-link" href="https://github.com/hyperledger/fabric-chaincode-node/tree/{{ release }}">{{ release | escape }}</a>
-            {%- endfor -%}
-          </div>
-        </nav>
-      {%- endif -%}
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18px" height="15px">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+            </svg>
+          </span>
+        </label>
+
+        <div class="trigger">
+          <a class="page-link" href="https://github.com/hyperledger/fabric-chaincode-node/">View on GitHub</a>
+        </div>
+      </nav>
     </div>
   </header>
   


### PR DESCRIPTION
Replace branch links with single GitHub repo link

Also revert to release-2.0 jsdoc link since 2.1 has not been released yet

Signed-off-by: James Taylor <jamest@uk.ibm.com>