### PR TITLE
[FABCN-394] ChaincodeStub class / interface mismatch

### DIFF
--- a/libraries/fabric-shim/types/index.d.ts
+++ b/libraries/fabric-shim/types/index.d.ts
@@ -76,6 +76,7 @@ declare module 'fabric-shim' {
         getTxID(): string;
         getChannelID(): string;
         getCreator(): SerializedIdentity;
+        getMspID(): string;
         getTransient(): Map<string, Uint8Array>;
 
         getSignedProposal(): ChaincodeProposal.SignedProposal;


### PR DESCRIPTION
Correct missing function in the class definition

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>