### PR TITLE
Fix broken tutorials link

### DIFF
--- a/docs/_jsdoc/index.md
+++ b/docs/_jsdoc/index.md
@@ -13,7 +13,7 @@ The `fabric-shim` provides the *chaincode interface*, a lower level API for impl
 
 To confirm that the `fabric-shim` maintains API and functional compatibility with previous versions of Hyperledger Fabric.
 
-Detailed explanation on the concept and programming model can be found here: [http://hyperledger-fabric.readthedocs.io/en/latest/chaincode.html](http://hyperledger-fabric.readthedocs.io/en/latest/chaincode.html).
+A more detailed explanation on the concept and programming model can be found in the [smart contract processing topic](https://hyperledger-fabric.readthedocs.io/en/latest/developapps/smartcontract.html).
 
 ## Contract Interface
 
@@ -25,7 +25,7 @@ npm install --save fabric-contract-api
 
 ### Usage
 
-Implement a class that ends the `contract` class, a constructor is needed. 
+Implement a class that ends the `contract` class, a constructor is needed.
 The other functions will be invokable functions of your Smart Contract
 
 ```javascript

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ in various programming languages. There are two other smart contract SDKs availa
 
 ## Documentation
 
-Detailed explanation on the concepts and programming model for smart contracts can be found in the [Chaincode Tutorials section of the Hyperledger Fabric documentation](http://hyperledger-fabric.readthedocs.io/en/latest/chaincode.html).
+Detailed explanation on the concepts and programming model for smart contracts can be found in the [Chaincode for developers tutorial in the Hyperledger Fabric documentation](https://hyperledger-fabric.readthedocs.io/en/latest/chaincode.html).
 
 API documentation is available for each release:
 


### PR DESCRIPTION
The following link: http://hyperledger-fabric.readthedocs.io/en/latest/chaincode.html has been removed in the 2.0 documentation. Changing the link to the smart contract processing topic and the chaincode for developers tutorial.

Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>