### PR TITLE
Link local dependencies using the `file` type

### DIFF
--- a/apis/fabric-contract-api/package.json
+++ b/apis/fabric-contract-api/package.json
@@ -46,7 +46,7 @@
     "lines": 100
   },
   "dependencies": {
-    "fabric-shim-api": "3.0.0-unstable",
+    "fabric-shim-api": "file:../fabric-shim-api",
     "class-transformer": "^0.2.2",
     "fast-safe-stringify": "~2.0.7",
     "get-params": "^0.1.2",

--- a/libraries/fabric-ledger/package.json
+++ b/libraries/fabric-ledger/package.json
@@ -49,7 +49,7 @@
     "lines": 100
   },
   "dependencies": {
-    "fabric-contract-api": "3.0.0-unstable",
+    "fabric-contract-api": "file:../../apis/fabric-contract-api",
     "winston": "^3.2.1"
   },
   "devDependencies": {
@@ -70,6 +70,6 @@
     "ts-node": "^8.3.0",
     "ts-mockito": "^2.5.0",
     "typescript": "3.4.5",
-    "azure-mocha-reporter": "1.0.0"
+    "azure-mocha-reporter": "file:../../tools/azure-mocha-reporter"
   }
 }

--- a/libraries/fabric-shim-crypto/package.json
+++ b/libraries/fabric-shim-crypto/package.json
@@ -38,7 +38,7 @@
         "rewire": "4.0.1",
         "sinon": "7.5.0",
         "chai-things": "^0.2.0",
-        "azure-mocha-reporter": "1.0.0"
+        "azure-mocha-reporter": "file:../../tools/azure-mocha-reporter"
     },
     "nyc": {
         "exclude": [

--- a/libraries/fabric-shim/package.json
+++ b/libraries/fabric-shim/package.json
@@ -62,8 +62,8 @@
     "@grpc/proto-loader": "^0.5.4",
     "@types/node": "^8.9.4",
     "ajv": "^6.5.5",
-    "fabric-contract-api": "3.0.0-unstable",
-    "fabric-shim-api": "3.0.0-unstable",
+    "fabric-contract-api": "file:../../apis/fabric-contract-api",
+    "fabric-shim-api": "file:../../apis/fabric-shim-api",
     "fs-extra": "8.1.0",
     "reflect-metadata": "^0.1.12",
     "winston": "^3.2.1",
@@ -82,6 +82,6 @@
     "rewire": "4.0.1",
     "rimraf": "^3.0.0",
     "sinon": "7.5.0",
-    "azure-mocha-reporter": "1.0.0"
+    "azure-mocha-reporter": "file:../../tools/azure-mocha-reporter"
   }
 }


### PR DESCRIPTION
Adds the dependencies that are part of the same repository using the local file link, rather than using the build tag.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>