### PR TITLE
[FABCN-408] Separate message handler from client

### DIFF
--- a/libraries/fabric-shim/lib/chaincode.js
+++ b/libraries/fabric-shim/lib/chaincode.js
@@ -14,7 +14,7 @@ const Logger = require('./logger');
 const utils = require('./utils/utils');
 
 const logger = Logger.getLogger('lib/chaincode.js');
-const Handler = require('./handler');
+const {ChaincodeSupportClient} = require('./handler');
 const Iterators = require('./iterators');
 const ChaincodeStub = require('./stub');
 const KeyEndorsementPolicy = require('./utils/statebased');
@@ -122,7 +122,7 @@ class Shim {
         }
 
         const chaincodeName = opts['chaincode-id-name'];
-        const client = new Handler(chaincode, url, optsCpy);
+        const client = new ChaincodeSupportClient(chaincode, url, optsCpy);
         const chaincodeID = {
             name: chaincodeName
         };

--- a/libraries/fabric-shim/lib/handler.js
+++ b/libraries/fabric-shim/lib/handler.js
@@ -205,7 +205,7 @@ class MsgQueueHandler {
 
 
 /*
- * The ChaincodeSupportClient class represents a the base class for all remote nodes, Peer, Orderer , and MemberServicespeer.
+ * The ChaincodeSupportClient class represents a chaincode gRPC client to the peer.
  */
 class ChaincodeSupportClient {
 
@@ -269,11 +269,37 @@ class ChaincodeSupportClient {
         this._stream.end();
     }
 
+    chat(convStarterMsg) {
+        this._stream = this._client.register();
+
+        this._handler = new ChaincodeMessageHandler(this._stream, this.chaincode);
+        this._handler.chat(convStarterMsg);
+    }
+
+    /*
+     return a printable representation of this object
+     */
+    toString() {
+        return 'ChaincodeSupportClient : {' +
+         'url:' +
+          this._url +
+           '}';
+    }
+}
+
+/**
+ * The ChaincodeMessageHandler class handles messages between peer and chaincode both in the chaincode server and client model.
+ */
+class ChaincodeMessageHandler {
+    constructor (stream, chaincode) {
+        this._stream = stream;
+        this.chaincode = chaincode;
+    }
+
     // this is a long-running method that does not return until
     // the conversation b/w the chaincode program and the target
     // peer has been completed
     chat(convStarterMsg) {
-        this._stream = this._client.register();
         this.msgQueueHandler = new MsgQueueHandler(this);
 
         const stream = this._stream;
@@ -528,15 +554,11 @@ class ChaincodeSupportClient {
         });
     }
 
-
     /*
-	 * return a printable representation of this object
-	 */
+     return a printable representation of this object
+     */
     toString() {
-        return 'ChaincodeSupportClient : {' +
-         'url:' +
-          this._url +
-           '}';
+        return 'ChaincodeMessageHandler : {}';
     }
 }
 
@@ -723,7 +745,10 @@ function parseResponse(handler, res, method) {
     }
 }
 
-module.exports = ChaincodeSupportClient;
+module.exports = {
+    ChaincodeSupportClient,
+    ChaincodeMessageHandler
+};
 
 //
 // The Endpoint class represents a remote grpc or grpcs target

--- a/libraries/fabric-shim/test/unit/chaincode.js
+++ b/libraries/fabric-shim/test/unit/chaincode.js
@@ -97,7 +97,7 @@ describe('Chaincode', () => {
         });
 
         it ('should start when passed init and invoke', () => {
-            const handlerClass = Chaincode.__get__('Handler');
+            const handlerClass = Chaincode.__get__('ChaincodeSupportClient');
             const chat = sandbox.stub(handlerClass.prototype, 'chat');
 
             const myYargs = {'argv': {'$0': 'fabric-chaincode-node', 'peer.address': 'localhost:7051', 'chaincode-id-name': 'mycc'}};
@@ -140,8 +140,8 @@ describe('Chaincode', () => {
             const myYargs = {'argv': {'$0': 'fabric-chaincode-node', 'peer.address': 'localhost:7051', 'chaincode-id-name': 'mycc', 'some-other-arg': 'another-arg', 'yet-another-bad-arg': 'arg'}};
             Chaincode.__set__('yargs', myYargs);
 
-            const handlerClass = Chaincode.__get__('Handler');
-            Chaincode.__set__('Handler', MockHandler);
+            const handlerClass = Chaincode.__get__('ChaincodeSupportClient');
+            Chaincode.__set__('ChaincodeSupportClient', MockHandler);
 
             const getArgsStub = sandbox.stub(StartCommand, 'getArgs').returns({
                 'peer.address': 'localhost:7051',
@@ -162,7 +162,7 @@ describe('Chaincode', () => {
             expect(testOpts.hasOwnProperty('module-path')).to.be.false;
             expect(testOpts.hasOwnProperty('peer.address')).to.be.true;
 
-            Chaincode.__set__('Handler', handlerClass);
+            Chaincode.__set__('ChaincodeSupportClient', handlerClass);
 
             getArgsStub.restore();
         });
@@ -213,7 +213,7 @@ describe('Chaincode', () => {
 
             it ('should call handler.chat() with the correct object and output a message', () => {
 
-                const handlerClass = Chaincode.__get__('Handler');
+                const handlerClass = Chaincode.__get__('ChaincodeSupportClient');
                 const chat = sandbox.stub(handlerClass.prototype, 'chat');
 
                 process.env.CORE_TLS_CLIENT_KEY_PATH = keyPath;
@@ -247,8 +247,8 @@ describe('Chaincode', () => {
                     }
                 }
 
-                const handlerClass = Chaincode.__get__('Handler');
-                Chaincode.__set__('Handler', MockHandler);
+                const handlerClass = Chaincode.__get__('ChaincodeSupportClient');
+                Chaincode.__set__('ChaincodeSupportClient', MockHandler);
 
                 process.env.CORE_TLS_CLIENT_KEY_PATH = keyPath;
                 process.env.CORE_TLS_CLIENT_CERT_PATH = certPath;
@@ -262,7 +262,7 @@ describe('Chaincode', () => {
                 testOpts.cert.should.equal(cert);
                 testOpts.key.should.equal(key);
 
-                Chaincode.__set__('Handler', handlerClass);
+                Chaincode.__set__('ChaincodeSupportClient', handlerClass);
             });
         });
     });

--- a/libraries/fabric-shim/test/unit/iterators.js
+++ b/libraries/fabric-shim/test/unit/iterators.js
@@ -14,7 +14,7 @@ const rewire = require('rewire');
 const Iterator = rewire('../../../fabric-shim/lib/iterators.js');
 const StateQueryIterator = Iterator.StateQueryIterator;
 const HistoryQueryIterator = Iterator.HistoryQueryIterator;
-const handler = require('../../../fabric-shim/lib/handler.js');
+const {ChaincodeMessageHandler} = require('../../../fabric-shim/lib/handler.js');
 const fabprotos = require('../../bundle');
 
 const channel_id = 'theChannelId';
@@ -26,7 +26,7 @@ describe('Iterator', () => {
     let sandbox;
     beforeEach(() => {
         sandbox = sinon.createSandbox();
-        mockHandler = sandbox.createStubInstance(handler);
+        mockHandler = sandbox.createStubInstance(ChaincodeMessageHandler);
         mockResponse = {};
     });
 


### PR DESCRIPTION
This patch divides the ChaincodeSupportClient class into two classes:
ChaincodeSupportClient, which represents a chaincode client that
connects to a peer, and ChaincodeMessageHandler, which handles messages
in communciation with the peer through a stream.

Because the latter part is common in both client and server model,
the ChaincodeMessageHandler class will be used in the future
implementation for a chaincode gRPC server.

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>