### PR TITLE
[FABCN-407] Update protos (#154)

### DIFF
--- a/libraries/fabric-shim/protos/common/common.proto
+++ b/libraries/fabric-shim/protos/common/common.proto
@@ -40,13 +40,13 @@ enum HeaderType {
 
 // This enum enlists indexes of the block metadata array
 enum BlockMetadataIndex {
-    SIGNATURES = 0;                  // Block metadata array position for block signatures
-    LAST_CONFIG = 1;                 // Block metadata array position to store last configuration block sequence number
-    TRANSACTIONS_FILTER = 2;         // Block metadata array position to store serialized bit array filter of invalid transactions
-    ORDERER = 3 [deprecated=true];   /* Block metadata array position to store operational metadata for orderers
-                                        e.g. For Kafka, this is where we store the last offset written to the local ledger */
-    COMMIT_HASH = 4;                 /* Block metadata array position to store the hash of TRANSACTIONS_FILTER, State Updates,
-                                        and the COMMIT_HASH of the previous block */
+    SIGNATURES = 0;                    // Block metadata array position for block signatures
+    LAST_CONFIG = 1 [deprecated=true]; // Block metadata array position to store last configuration block sequence number
+    TRANSACTIONS_FILTER = 2;           // Block metadata array position to store serialized bit array filter of invalid transactions
+    ORDERER = 3 [deprecated=true];     /* Block metadata array position to store operational metadata for orderers
+                                          e.g. For Kafka, this is where we store the last offset written to the local ledger */
+    COMMIT_HASH = 4;                   /* Block metadata array position to store the hash of TRANSACTIONS_FILTER, State Updates,
+                                          and the COMMIT_HASH of the previous block */
 }
 
 // LastConfig is the encoded value for the Metadata message which is encoded in the LAST_CONFIGURATION block metadata index

--- a/libraries/fabric-shim/protos/common/configtx.proto
+++ b/libraries/fabric-shim/protos/common/configtx.proto
@@ -39,16 +39,6 @@ message ConfigEnvelope {
                               // Note that CONFIG_UPDATE has a Payload.Data of a Marshaled ConfigUpdate
 }
 
-message ConfigGroupSchema {
-    map<string, ConfigGroupSchema> groups = 1;
-    map<string, ConfigValueSchema> values = 2;
-    map<string, ConfigPolicySchema> policies = 3;
-}
-
-message ConfigValueSchema {}
-
-message ConfigPolicySchema {}
-
 // Config represents the config for a particular channel
 message Config {
     // Prevent removed tag re-use

--- a/libraries/fabric-shim/protos/common/policies.proto
+++ b/libraries/fabric-shim/protos/common/policies.proto
@@ -65,3 +65,20 @@ message ImplicitMetaPolicy {
     string sub_policy = 1;
     Rule rule = 2;
 }
+
+// ApplicationPolicy captures the diffenrent policy types that
+// are set and evaluted at the application level.
+message ApplicationPolicy {
+    option deprecated = true;
+    oneof Type {
+        // SignaturePolicy type is used if the policy is specified as
+        // a combination (using threshold gates) of signatures from MSP
+        // principals
+        SignaturePolicyEnvelope signature_policy = 1;
+
+        // ChannelConfigPolicyReference is used when the policy is
+        // specified as a string that references a policy defined in
+        // the configuration of the channel
+        string channel_config_policy_reference = 2;
+    }
+}

--- a/libraries/fabric-shim/protos/discovery/protocol.proto
+++ b/libraries/fabric-shim/protos/discovery/protocol.proto
@@ -156,6 +156,8 @@ message ChaincodeInterest {
 message ChaincodeCall {
     string name = 1;
     repeated string collection_names = 2;
+    bool no_private_reads = 3; // Indicates we do not need to read from private data
+    bool no_public_writes = 4; // Indicates we do not need to write to the chaincode namespace
 }
 
 // ChaincodeQueryResult contains EndorsementDescriptors for

--- a/libraries/fabric-shim/protos/gossip/message.proto
+++ b/libraries/fabric-shim/protos/gossip/message.proto
@@ -9,7 +9,7 @@ option java_package = "org.hyperledger.fabric.protos.gossip";
 
 package gossip;
 
-import "common/collection.proto";
+import "peer/collection.proto";
 
 // Gossip
 service Gossip {
@@ -175,6 +175,7 @@ message ConnEstablish {
     bytes pki_id          = 1;
     bytes identity        = 2;
     bytes tls_cert_hash   = 3;
+    bool probe            = 4;
 }
 
 // PeerIdentity defines the identity of the peer
@@ -257,7 +258,7 @@ message PrivatePayload {
     string tx_id                = 3;
     bytes private_rwset         = 4;
     uint64 private_sim_height  = 5;
-    common.CollectionConfigPackage collection_configs = 6;
+    protos.CollectionConfigPackage collection_configs = 6;
 }
 
 // Membership messages

--- a/libraries/fabric-shim/protos/peer/chaincode_shim.proto
+++ b/libraries/fabric-shim/protos/peer/chaincode_shim.proto
@@ -177,3 +177,9 @@ message StateMetadataResult {
 service ChaincodeSupport {
     rpc Register(stream ChaincodeMessage) returns (stream ChaincodeMessage);
 }
+
+// Chaincode as a server - peer establishes a connection to the chaincode as a client
+// Currently only supports a stream connection.
+service Chaincode {
+    rpc Connect(stream ChaincodeMessage) returns (stream ChaincodeMessage);
+}

--- a/libraries/fabric-shim/protos/peer/collection.proto
+++ b/libraries/fabric-shim/protos/peer/collection.proto
@@ -4,18 +4,18 @@
 
 syntax = "proto3";
 
-option go_package = "github.com/hyperledger/fabric-protos-go/common";
-option java_package = "org.hyperledger.fabric.protos.common";
+option go_package = "github.com/hyperledger/fabric-protos-go/peer";
+option java_package = "org.hyperledger.fabric.protos.peer";
 
-package common;
+package protos;
 
 import "common/policies.proto";
+import "peer/policy.proto";
 
 // CollectionConfigPackage represents an array of CollectionConfig
 // messages; the extra struct is required because repeated oneof is
 // forbidden by the protobuf syntax
 message CollectionConfigPackage {
-    option deprecated = true;
     repeated CollectionConfig config = 1;
 }
 
@@ -23,7 +23,6 @@ message CollectionConfigPackage {
 // it currently contains a single, static type.
 // Dynamic collections are deferred.
 message CollectionConfig {
-    option deprecated = true;
     oneof payload {
         StaticCollectionConfig static_collection_config = 1;
     }
@@ -35,7 +34,6 @@ message CollectionConfig {
 // known at chaincode instantiation time, and that cannot be changed.
 // Dynamic collections are deferred.
 message StaticCollectionConfig {
-    option deprecated = true;
     // the name of the collection inside the denoted chaincode
     string name = 1;
     // a reference to a policy residing / managed in the config block
@@ -73,10 +71,9 @@ message StaticCollectionConfig {
 // more general Policy. Instead of containing the actual policy, the
 // configuration may in the future contain a string reference to a policy.
 message CollectionPolicyConfig {
-    option deprecated = true;
     oneof payload {
         // Initially, only a signature policy is supported.
-        SignaturePolicyEnvelope signature_policy = 1;
+        common.SignaturePolicyEnvelope signature_policy = 1;
         // Later, the SignaturePolicy will be replaced by a Policy.
         //        Policy policy = 1;
         // A reference to a Policy is planned to be added later.

--- a/libraries/fabric-shim/protos/peer/lifecycle/lifecycle.proto
+++ b/libraries/fabric-shim/protos/peer/lifecycle/lifecycle.proto
@@ -9,7 +9,7 @@ option go_package = "github.com/hyperledger/fabric-protos-go/peer/lifecycle";
 
 package lifecycle;
 
-import "common/collection.proto";
+import "peer/collection.proto";
 
 // InstallChaincodeArgs is the message used as the argument to
 // '_lifecycle.InstallChaincode'.
@@ -97,7 +97,7 @@ message ApproveChaincodeDefinitionForMyOrgArgs {
     string endorsement_plugin = 4;
     string validation_plugin = 5;
     bytes validation_parameter = 6;
-    common.CollectionConfigPackage collections = 7;
+    protos.CollectionConfigPackage collections = 7;
     bool init_required = 8;
     ChaincodeSource source = 9;
 }
@@ -130,7 +130,7 @@ message CommitChaincodeDefinitionArgs {
     string endorsement_plugin = 4;
     string validation_plugin = 5;
     bytes validation_parameter = 6;
-    common.CollectionConfigPackage collections = 7;
+    protos.CollectionConfigPackage collections = 7;
     bool init_required = 8;
 }
 
@@ -149,7 +149,7 @@ message CheckCommitReadinessArgs {
     string endorsement_plugin = 4;
     string validation_plugin = 5;
     bytes validation_parameter = 6;
-    common.CollectionConfigPackage collections = 7;
+    protos.CollectionConfigPackage collections = 7;
     bool init_required = 8;
 }
 
@@ -159,6 +159,26 @@ message CheckCommitReadinessArgs {
 // supplied as args.
 message CheckCommitReadinessResult{
     map<string, bool> approvals = 1;
+}
+
+// QueryApprovedChaincodeDefinitionArgs is the message used as arguments to
+// `_lifecycle.QueryApprovedChaincodeDefinition`.
+message QueryApprovedChaincodeDefinitionArgs {
+    string name = 1;
+    int64 sequence = 2;
+}
+
+// QueryApprovedChaincodeDefinitionResult is the message returned by
+// `_lifecycle.QueryApprovedChaincodeDefinition`.
+message QueryApprovedChaincodeDefinitionResult {
+    int64 sequence = 1;
+    string version = 2;
+    string endorsement_plugin = 3;
+    string validation_plugin = 4;
+    bytes validation_parameter = 5;
+    protos.CollectionConfigPackage collections = 6;
+    bool init_required = 7;
+    ChaincodeSource source = 8;
 }
 
 // QueryChaincodeDefinitionArgs is the message used as arguments to
@@ -175,7 +195,7 @@ message QueryChaincodeDefinitionResult {
     string endorsement_plugin = 3;
     string validation_plugin = 4;
     bytes validation_parameter = 5;
-    common.CollectionConfigPackage collections = 6;
+    protos.CollectionConfigPackage collections = 6;
     bool init_required = 7;
     map<string,bool> approvals = 8;
 }
@@ -194,7 +214,7 @@ message QueryChaincodeDefinitionsResult {
         string endorsement_plugin = 4;
         string validation_plugin = 5;
         bytes validation_parameter = 6;
-        common.CollectionConfigPackage collections = 7;
+        protos.CollectionConfigPackage collections = 7;
         bool init_required = 8;
     }
     repeated ChaincodeDefinition chaincode_definitions = 1;

--- a/libraries/fabric-shim/protos/peer/transaction.proto
+++ b/libraries/fabric-shim/protos/peer/transaction.proto
@@ -13,20 +13,6 @@ package protos;
 import "peer/proposal_response.proto";
 import "common/common.proto";
 
-// This message is necessary to facilitate the verification of the signature
-// (in the signature field) over the bytes of the transaction (in the
-// transactionBytes field).
-message SignedTransaction {
-    // The bytes of the Transaction. NDD
-    bytes transaction_bytes = 1;
-
-    // Signature of the transactionBytes The public key of the signature is in
-    // the header field of TransactionAction There might be multiple
-    // TransactionAction, so multiple headers, but there should be same
-    // transactor identity (cert) in all headers
-    bytes signature = 2;
-}
-
 // ProcessedTransaction wraps an Envelope that includes a transaction along with an indication
 // of whether the transaction was validated or invalidated by committing peer.
 // The use case is that GetTransactionByID API needs to retrieve the transaction Envelope

--- a/libraries/fabric-shim/protos/transientstore/transientstore.proto
+++ b/libraries/fabric-shim/protos/transientstore/transientstore.proto
@@ -10,7 +10,7 @@ option go_package = "github.com/hyperledger/fabric-protos-go/transientstore";
 option java_package = "org.hyperledger.fabric.protos.transientstore";
 
 import "ledger/rwset/rwset.proto";
-import "common/collection.proto";
+import "peer/collection.proto";
 
 // TxPvtReadWriteSetWithConfigInfo encapsulates the transaction's private
 // read-write set and additional information about the configurations such as
@@ -18,5 +18,5 @@ import "common/collection.proto";
 message TxPvtReadWriteSetWithConfigInfo {
     uint64 endorsed_at = 1;
     rwset.TxPvtReadWriteSet pvt_rwset = 2;
-    map<string, common.CollectionConfigPackage> collection_configs = 3;
+    map<string, protos.CollectionConfigPackage> collection_configs = 3;
 }


### PR DESCRIPTION
This is cherry-pick for release-2.x of #154

To prepare for the implementation of chaincode gRPC server, this patch
updates protobuf definitions to the latest ones.

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>
