### PR TITLE
[FABCN-410] Use new lifecycle for fv/e2e tests

### DIFF
--- a/test/fv/utils.js
+++ b/test/fv/utils.js
@@ -22,7 +22,25 @@ const getTLSArgs = () => {
 
     return '';
 };
+const getPeerAddresses = () => {
+    if (tls) {
+        return '--peerAddresses peer0.org1.example.com:7051 --tlsRootCertFile ' + org1CA +
+            ' --peerAddresses peer0.org2.example.com:8051 --tlsRootCertFile ' + org2CA;
+    } else {
+        return '--peerAddresses peer0.org1.example.com:7051' +
+            ' --peerAddresses peer0.org2.example.com:8051';
+    }
+};
+const findPackageId = (queryOutput, label) => {
+    const output = JSON.parse(queryOutput);
 
+    const cc = output.installed_chaincodes.filter((chaincode) => chaincode.label === label);
+    if (cc.length !== 1) {
+        throw new Error('Failed to find installed chaincode');
+    }
+
+    return cc[0].package_id;
+};
 
 // Increase the timeouts on zLinux!
 const arch = require('os').arch();
@@ -33,20 +51,42 @@ async function install(ccName) {
     try {
         fs.writeFileSync(npmrc, `registry=http://${ip.address()}:4873`);
         const folderName = '/opt/gopath/src/github.com/chaincode/' + ccName;
-        const cmd = `docker exec %s peer chaincode install -l node -n ${ccName} -v v0 -p ${folderName} --connTimeout 60s`;       
-        await exec(util.format(cmd, 'org1_cli'));
-        await exec(util.format(cmd, 'org2_cli'));
+        const packageCmd = `docker exec %s peer lifecycle chaincode package -l node /tmp/${ccName}.tar.gz -p ${folderName} --label ${ccName}_v0`;
+        await exec(util.format(packageCmd, 'org1_cli'));
+        await exec(util.format(packageCmd, 'org2_cli'));
 
+        const installCmd = `docker exec %s peer lifecycle chaincode install /tmp/${ccName}.tar.gz --connTimeout 60s`;
+        await exec(util.format(installCmd, 'org1_cli'));
+        await exec(util.format(installCmd, 'org2_cli'));
     } finally {
         fs.unlinkSync(npmrc);
     }
 }
 
 async function instantiate(ccName, func, args) {
-    const cmd = `docker exec org1_cli peer chaincode instantiate ${getTLSArgs()} -o orderer.example.com:7050 -l node -C mychannel -n ${ccName} -v v0 -c '${printArgs(func, args)}' -P 'OR ("Org1MSP.member")'`;
-    console.log(cmd)
-    const res = await exec(cmd);
+    const orgs = ['org1', 'org2'];
+    const endorsementPolicy = '\'OR ("Org1MSP.member")\'';
+
+    for (const org of orgs) {
+        const queryInstalledCmd = `docker exec ${org}_cli peer lifecycle chaincode queryinstalled --output json`;
+        const res = await exec(queryInstalledCmd);
+        const pkgId = findPackageId(res.stdout.toString(), ccName + '_v0');
+        const approveCmd = `docker exec ${org}_cli peer lifecycle chaincode approveformyorg ${getTLSArgs()} -o orderer.example.com:7050` +
+            ` -C mychannel -n ${ccName} -v v0 --init-required --sequence 1 --package-id ${pkgId} --signature-policy ${endorsementPolicy}`;
+
+        await exec(approveCmd);
+    }
+
+    const commitCmd = `docker exec org1_cli peer lifecycle chaincode commit ${getTLSArgs()} -o orderer.example.com:7050` +
+        ` -C mychannel -n ${ccName} -v v0 --init-required --sequence 1 --signature-policy ${endorsementPolicy} ${getPeerAddresses()}`;
+
+    console.log(commitCmd);
+    await exec(commitCmd);
     await new Promise(resolve => setTimeout(resolve, 5000));
+
+    const initCmd = `docker exec org1_cli peer chaincode invoke ${getTLSArgs()} -o orderer.example.com:7050 -C mychannel -n ${ccName} --isInit -c '${printArgs(func, args)}' --waitForEvent`;
+    const res = await exec(initCmd);
+
     return res;
 }
 

--- a/tools/toolchain/index.js
+++ b/tools/toolchain/index.js
@@ -1,5 +1,7 @@
 const {shell} = require('./shell/cmd');
-const getTLSArgs = require('./utils').getTLSArgs;
+const {getTLSArgs, getPeerAddresses} = require('./utils');
+
 module.exports.shell = shell;
 
 module.exports.getTLSArgs = getTLSArgs;
+module.exports.getPeerAddresses = getPeerAddresses;

--- a/tools/toolchain/network/crypto-material/configtx.yaml
+++ b/tools/toolchain/network/crypto-material/configtx.yaml
@@ -39,20 +39,20 @@ Capabilities:
     # Channel capabilities apply to both the orderers and the peers and must be
     # supported by both.  Set the value of the capability to true to require it.
     Channel: &ChannelCapabilities
-        V1_1: true
+        V2_0: true
 
     # Orderer capabilities apply only to the orderers, and may be safely
     # manipulated without concern for upgrading peers.  Set the value of the
     # capability to true to require it.
     Orderer: &OrdererCapabilities
-        V1_1: true
+        V2_0: true
 
     # Application capabilities apply only to the peer network, and may be
     # safely manipulated without concern for upgrading orderers.  Set the value
     # of the capability to true to require it.
     Application: &ApplicationCapabilities
-        V1_2: true
-        V1_1: false
+        V2_0: true
+
 ################################################################################
 #
 #   CHANNEL

--- a/tools/toolchain/utils.js
+++ b/tools/toolchain/utils.js
@@ -1,4 +1,6 @@
 const ordererCA = '/etc/hyperledger/config/crypto-config/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem';
+const org1CA = '/etc/hyperledger/config/crypto-config/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem';
+const org2CA = '/etc/hyperledger/config/crypto-config/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem';
 
 const tls = process.env.TLS && process.env.TLS.toLowerCase() === 'true' ? true : false;
 
@@ -10,4 +12,14 @@ exports.getTLSArgs = () => {
     }
 
     return '';
+};
+
+exports.getPeerAddresses = () => {
+    if (tls) {
+        return '--peerAddresses peer0.org1.example.com:7051 --tlsRootCertFile ' + org1CA +
+            ' --peerAddresses peer0.org2.example.com:8051 --tlsRootCertFile ' + org2CA;
+    } else {
+        return '--peerAddresses peer0.org1.example.com:7051' +
+            ' --peerAddresses peer0.org2.example.com:8051';
+    }
 };


### PR DESCRIPTION
This patch enables v2.0 feature in the test Hyperledger Fabric network
and uses new lifecycle commands in the fv and e2e tests.

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>

This is also intended for preparation for the chaincode server.