### PR TITLE
[FABCN-410] Use new lifecycle for fv/e2e tests

### DIFF
--- a/tools/toolchain/index.js
+++ b/tools/toolchain/index.js
@@ -1,5 +1,7 @@
 const {shell} = require('./shell/cmd');
-const getTLSArgs = require('./utils').getTLSArgs;
+const {getTLSArgs, getPeerAddresses} = require('./utils');
+
 module.exports.shell = shell;
 
 module.exports.getTLSArgs = getTLSArgs;
+module.exports.getPeerAddresses = getPeerAddresses;

--- a/tools/toolchain/network/crypto-material/configtx.yaml
+++ b/tools/toolchain/network/crypto-material/configtx.yaml
@@ -39,20 +39,20 @@ Capabilities:
     # Channel capabilities apply to both the orderers and the peers and must be
     # supported by both.  Set the value of the capability to true to require it.
     Channel: &ChannelCapabilities
-        V1_1: true
+        V2_0: true
 
     # Orderer capabilities apply only to the orderers, and may be safely
     # manipulated without concern for upgrading peers.  Set the value of the
     # capability to true to require it.
     Orderer: &OrdererCapabilities
-        V1_1: true
+        V2_0: true
 
     # Application capabilities apply only to the peer network, and may be
     # safely manipulated without concern for upgrading orderers.  Set the value
     # of the capability to true to require it.
     Application: &ApplicationCapabilities
-        V1_2: true
-        V1_1: false
+        V2_0: true
+
 ################################################################################
 #
 #   CHANNEL

--- a/tools/toolchain/utils.js
+++ b/tools/toolchain/utils.js
@@ -1,4 +1,6 @@
 const ordererCA = '/etc/hyperledger/config/crypto-config/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem';
+const org1CA = '/etc/hyperledger/config/crypto-config/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem';
+const org2CA = '/etc/hyperledger/config/crypto-config/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem';
 
 const tls = process.env.TLS && process.env.TLS.toLowerCase() === 'true' ? true : false;
 
@@ -10,4 +12,14 @@ exports.getTLSArgs = () => {
     }
 
     return '';
+};
+
+exports.getPeerAddresses = () => {
+    if (tls) {
+        return '--peerAddresses peer0.org1.example.com:7051 --tlsRootCertFile ' + org1CA +
+            ' --peerAddresses peer0.org2.example.com:8051 --tlsRootCertFile ' + org2CA;
+    } else {
+        return '--peerAddresses peer0.org1.example.com:7051' +
+            ' --peerAddresses peer0.org2.example.com:8051';
+    }
 };


### PR DESCRIPTION
This is cherry-picking of #158 to the release-2.x branch.

This patch enables v2.0 feature in the test Hyperledger Fabric network
and uses new lifecycle commands in the fv and e2e tests.

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>