### PR TITLE
Fix 'rush install' error in release-2.x

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -24,7 +24,7 @@
      * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
      * for details about these alternatives.
      */
-     "pnpmVersion": "4.1.7",
+     "pnpmVersion": "4.7.2",
     /**
      * Options that are only used when the PNPM package manager is selected
      */


### PR DESCRIPTION
This patch upgrades pnpm to fix the "Could not find peer dependency
'google-auth-library'" error in CI.

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>