### PR TITLE
[FABCN-414] Update TypeScript definition

### DIFF
--- a/libraries/fabric-shim/types/index.d.ts
+++ b/libraries/fabric-shim/types/index.d.ts
@@ -45,6 +45,24 @@ declare module 'fabric-shim' {
         static newLogger(name: string): Logger;
         static start(chaincode: ChaincodeInterface): any;
         static success(payload?: Uint8Array): ChaincodeResponse;
+        static server(chaincode: ChaincodeInterface, serverOpts: ChaincodeServerOpts): ChaincodeServer;
+    }
+
+    export class ChaincodeServer {
+        constructor(chaincode: ChaincodeInterface, serverOpts: ChaincodeServerOpts);
+        start(): Promise<void>;
+    }
+
+    export interface ChaincodeServerOpts {
+        ccid: string;
+        address: string;
+        tlsProps: ChaincodeServerTLSProperties;
+    }
+
+    export interface ChaincodeServerTLSProperties {
+        key: Buffer;
+        cert: Buffer;
+        clientCACerts: Buffer;
     }
 
     export class ClientIdentity implements IClientIdentity {


### PR DESCRIPTION
This patch updates the type defintion file for TypeScript to add classes
and interfaces related to the chaincode server feature.

Depends on #164

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>