### PR TITLE
[FABCN-415] Lock grpc-js to 1.0.3

### DIFF
--- a/libraries/fabric-shim/package.json
+++ b/libraries/fabric-shim/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fidm/x509": "^1.2.1",
-    "@grpc/grpc-js": "^1.0.3",
+    "@grpc/grpc-js": "1.0.3",
     "@grpc/proto-loader": "^0.5.4",
     "@types/node": "^8.9.4",
     "ajv": "^6.5.5",


### PR DESCRIPTION
@grpc/grpc-js@1.1.0 release seems to have caused the initial coms to the peer to fail. Dropping back to 1.0.3

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>