### PR TITLE
Use Official CouchDB 3.1 Image

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -43,7 +43,7 @@ variables:
   - name: node_version_spec
     value: '12.15.0'
   - name: FABRIC_VERSION
-    value: 2.1
+    value: 2.2
 
 # Build on Ubuntu
 pool:

--- a/tools/getEdgeDocker.sh
+++ b/tools/getEdgeDocker.sh
@@ -6,7 +6,7 @@
 #
 set -euo pipefail
 
-version=${FABRIC_VERSION:-2.1}
+version=${FABRIC_VERSION:-2.2}
 artifactory_url=hyperledger-fabric.jfrog.io
 
 for image in peer orderer ca baseos ccenv tools; do
@@ -16,7 +16,7 @@ for image in peer orderer ca baseos ccenv tools; do
     docker rmi -f "${artifactory_image}" >/dev/null
 done
 
-docker pull -q hyperledger/fabric-couchdb
+docker pull -q couchdb:3.1
 docker pull -q hyperledger/fabric-ca:1.4
 docker tag hyperledger/fabric-ca:1.4 hyperledger/fabric-ca
 docker rmi hyperledger/fabric-ca:1.4 >/dev/null

--- a/tools/toolchain/network/docker-compose/docker-compose-base.yaml
+++ b/tools/toolchain/network/docker-compose/docker-compose-base.yaml
@@ -95,6 +95,9 @@ services:
       - CORE_CHAINCODE_NODE_RUNTIME=hyperledger/fabric-nodeenv
       # Allow more time for chaincode container to build on install.
       - CORE_CHAINCODE_EXECUTETIMEOUT=300s
+
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=admin
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=adminpw
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     command: peer node start --peer-chaincodedev=true
     volumes:
@@ -129,4 +132,7 @@ services:
 
   couchdb:
     container_name: couchdb
-    image: hyperledger/fabric-couchdb
+    image: couchdb:3.1
+    environment:
+      - COUCHDB_USER=admin
+      - COUCHDB_PASSWORD=adminpw


### PR DESCRIPTION
Fabric 2.2 removes official support for CouchDB 2.x.
The migration to 3.1 was to address fsync issues
in the underlying storage implementation in Couch.

This change moves to CouchDB 3.1 which requires the
user to now set an admin identity at startup.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>