### PR TITLE
Use Official CouchDB 3.1 Image (#180)

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -41,7 +41,9 @@ variables:
   - name: pipeline
     value: ci
   - name: node_version_spec
-    value: '12.16.1'
+    value: '12.18.2'
+  - name: FABRIC_VERSION
+    value: 2.2
 
 # Build on Ubuntu
 pool:

--- a/tools/getEdgeDocker.sh
+++ b/tools/getEdgeDocker.sh
@@ -1,52 +1,22 @@
-#!/bin/bash -e
+#!/bin/bash
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 set -euo pipefail
 
-echo "======== PULL DOCKER IMAGES ========"
+version=${FABRIC_VERSION:-2.2}
+artifactory_url=hyperledger-fabric.jfrog.io
 
-###############################################################
-# Pull and Tag the fabric and fabric-ca images from Artifactory
-###############################################################
-echo "Fetching images from Artifactory"
-ARTIFACTORY_URL=hyperledger-fabric.jfrog.io
-ORG_NAME="hyperledger"
+for image in peer orderer ca baseos ccenv tools; do
+    artifactory_image="${artifactory_url}/fabric-${image}:amd64-${version}-stable"
+    docker pull -q "${artifactory_image}"
+    docker tag "${artifactory_image}" "hyperledger/fabric-${image}"
+    docker rmi -f "${artifactory_image}" >/dev/null
+done
 
-VERSION=2.1
-CA_VERSION=1.4
-ARCH="amd64"
-MASTER_TAG=$ARCH-master
-
-# Specifically not pulling down javaenv nodeenv
-# javaenv not needed and we've just rebuilt the nodeenv
-
-dockerTag() {
-  for IMAGES in peer orderer ca baseos ccenv tools; do
-    echo "Images: $IMAGES"
-    echo
-
-    if [ "${IMAGES}" = "ca" ]; then
-      STABLE_TAG=$ARCH-$CA_VERSION-stable
-    else
-      STABLE_TAG=$ARCH-$VERSION-stable
-    fi
-    echo "---------> STABLE_TAG:" $STABLE_TAG
-    echo
-
-    docker pull $ARTIFACTORY_URL/fabric-$IMAGES:$STABLE_TAG
-    if [[ $? != 0 ]]; then
-      echo  "FAILED: Docker Pull Failed on $IMAGES"
-      exit 1
-    fi
-
-    docker tag $ARTIFACTORY_URL/fabric-$IMAGES:$STABLE_TAG $ORG_NAME/fabric-$IMAGES
-    docker tag $ARTIFACTORY_URL/fabric-$IMAGES:$STABLE_TAG $ORG_NAME/fabric-$IMAGES:$MASTER_TAG
-    echo "$ORG_NAME/fabric-$IMAGES:$MASTER_TAG"
-    echo "Deleting Artifactory docker images: $IMAGES"
-    docker rmi -f $ARTIFACTORY_URL/fabric-$IMAGES:$STABLE_TAG
-  done
-}
-
-dockerTag
-
-echo
-docker images | grep "hyperledger"
-echo
+docker pull -q couchdb:3.1
+docker pull -q hyperledger/fabric-ca:1.4
+docker tag hyperledger/fabric-ca:1.4 hyperledger/fabric-ca
+docker rmi hyperledger/fabric-ca:1.4 >/dev/null

--- a/tools/toolchain/network/docker-compose/docker-compose-base.yaml
+++ b/tools/toolchain/network/docker-compose/docker-compose-base.yaml
@@ -95,6 +95,9 @@ services:
       - CORE_CHAINCODE_NODE_RUNTIME=hyperledger/fabric-nodeenv:2.1.5-unstable
       # Allow more time for chaincode container to build on install.
       - CORE_CHAINCODE_EXECUTETIMEOUT=300s
+
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=admin
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=adminpw
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     command: peer node start --peer-chaincodedev=${DOCKER_DEVMODE}
     volumes:
@@ -129,4 +132,7 @@ services:
 
   couchdb:
     container_name: couchdb
-    image: hyperledger/fabric-couchdb${THIRDPARTY_IMG_TAG}
+    image: couchdb:3.1
+    environment:
+      - COUCHDB_USER=admin
+      - COUCHDB_PASSWORD=adminpw


### PR DESCRIPTION
Fabric 2.2 removes official support for CouchDB 2.x.
The migration to 3.1 was to address fsync issues
in the underlying storage implementation in Couch.

This change moves to CouchDB 3.1 which requires the
user to now set an admin identity at startup.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>