### PR TITLE
[FABCN-435] OOM on large arg size

### DIFF
--- a/fabric-shim/lib/handler.js
+++ b/fabric-shim/lib/handler.js
@@ -281,7 +281,7 @@ class ChaincodeSupportClient {
         let state = 'created';
 
         stream.on('data', function (msg) {
-            logger.debug('Received chat message from peer: %j, state: %s', msg, state);
+            logger.debug('Received chat message from peer: %s, state: %s', msg.txid, state);
 
             if (state === STATES.Ready) {
                 const type = msg.type;


### PR DESCRIPTION
Trace point incorrectly logging entire binary message payload
Causes OOM errors.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>