### PR TITLE
Publish 2.2 api docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,4 +3,4 @@ title: "fabric-chaincode-node"
 releases:
   - master
   - release-1.4
-  - release-2.x
+  - release-2.2


### PR DESCRIPTION
Hopefully just need to trigger a merge build to publish the 2.2 docs

Note: _config.yml is only used in the master branch build
Signed-off-by: James Taylor <jamest@uk.ibm.com>