### PR TITLE
Update node versions

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -41,7 +41,9 @@ variables:
   - name: pipeline
     value: ci
   - name: node_version_spec
-    value: '12.18.2'
+    value: '12.16.1'
+  - name: rewire_node_version_spec # see https://github.com/jhnns/rewire/issues/178
+    value: '12.15.0'
   - name: FABRIC_VERSION
     value: 2.2
 
@@ -66,7 +68,7 @@ stages:
           steps:
             - task: NodeTool@0
               inputs:
-                versionSpec: 12.15.0
+                versionSpec: $(rewire_node_version_spec)
             - script: |
                 set -ev
                 node common/scripts/install-run-rush.js install


### PR DESCRIPTION
Node versions did not match docker image. Also clarifies why unit tests cannot use
the correct version.

Signed-off-by: James Taylor <jamest@uk.ibm.com>