### PR TITLE
Fix typo on fabric-contract-api

### DIFF
--- a/apis/fabric-contract-api/lib/contract.js
+++ b/apis/fabric-contract-api/lib/contract.js
@@ -123,7 +123,7 @@ class Contract {
     }
 
     /**
-     * @return {String} returns the namepsace
+     * @return {String} returns the namespace
      */
     getName() {
         return this.name;


### PR DESCRIPTION
Fixes typo in `getName` function header