### PR TITLE
Improve compliance with repolinter

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,5 +8,5 @@ There are two ways to report a security bug. The easiest is to email a descripti
 
 The other way is to file a confidential security bug in our [JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to “Security issue”.
 
-The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/HYP/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
+The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
 

--- a/apis/fabric-contract-api/lib/annotations/default.js
+++ b/apis/fabric-contract-api/lib/annotations/default.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 const Logger = require('../logger');

--- a/apis/fabric-contract-api/lib/annotations/index.js
+++ b/apis/fabric-contract-api/lib/annotations/index.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/apis/fabric-contract-api/lib/annotations/info.js
+++ b/apis/fabric-contract-api/lib/annotations/info.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 const Logger = require('../logger');

--- a/apis/fabric-contract-api/lib/annotations/object.js
+++ b/apis/fabric-contract-api/lib/annotations/object.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 const Logger = require('../logger');

--- a/apis/fabric-contract-api/lib/annotations/utils.js
+++ b/apis/fabric-contract-api/lib/annotations/utils.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 const refPath = '#/components/schemas/';

--- a/apis/fabric-contract-api/test/unit/annotations/default.js
+++ b/apis/fabric-contract-api/test/unit/annotations/default.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 const sinon = require('sinon');

--- a/apis/fabric-contract-api/test/unit/annotations/info.js
+++ b/apis/fabric-contract-api/test/unit/annotations/info.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 const sinon = require('sinon');

--- a/apis/fabric-contract-api/test/unit/annotations/object.js
+++ b/apis/fabric-contract-api/test/unit/annotations/object.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 const sinon = require('sinon');

--- a/apis/fabric-contract-api/test/unit/annotations/transaction.js
+++ b/apis/fabric-contract-api/test/unit/annotations/transaction.js
@@ -1,16 +1,9 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 /* global describe it beforeEach afterEach  */
 'use strict';
 

--- a/apis/fabric-contract-api/test/unit/annotations/utils.js
+++ b/apis/fabric-contract-api/test/unit/annotations/utils.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* global describe it  */

--- a/apis/fabric-contract-api/test/unit/context.js
+++ b/apis/fabric-contract-api/test/unit/context.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* global describe it beforeEach afterEach  */

--- a/apis/fabric-contract-api/test/unit/contract.js
+++ b/apis/fabric-contract-api/test/unit/contract.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 /* global describe it beforeEach afterEach  */
 'use strict';

--- a/apis/fabric-contract-api/test/unit/index.js
+++ b/apis/fabric-contract-api/test/unit/index.js
@@ -1,16 +1,9 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 'use strict';
 
 require('../../index.js');

--- a/apis/fabric-contract-api/test/unit/jsontransactionserializer.js
+++ b/apis/fabric-contract-api/test/unit/jsontransactionserializer.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* global describe it beforeEach afterEach  */

--- a/ci/updatePackageJson.js
+++ b/ci/updatePackageJson.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const fs = require('fs');
 let filename = process.argv[2];
 let input = JSON.parse(fs.readFileSync(filename));

--- a/libraries/fabric-shim/bundle.js
+++ b/libraries/fabric-shim/bundle.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
 (function(global, factory) { /* global define, require, module */
 

--- a/libraries/fabric-shim/cli.js
+++ b/libraries/fabric-shim/cli.js
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const version = 'v' + require('./package.json').version;
 const Logger = require('./lib/logger');
 

--- a/libraries/fabric-shim/lib/cmds/startCommand.js
+++ b/libraries/fabric-shim/lib/cmds/startCommand.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright contributors to Hyperledger Fabric.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 'use strict';

--- a/libraries/fabric-shim/lib/utils/utils.js
+++ b/libraries/fabric-shim/lib/utils/utils.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 module.exports.generateLoggingPrefix = (channelId, txId) => {
     return `[${channelId}-${shortTxID(txId)}]`;
 };

--- a/libraries/fabric-shim/test/unit/cli.js
+++ b/libraries/fabric-shim/test/unit/cli.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* global describe it beforeEach afterEach */

--- a/libraries/fabric-shim/test/unit/cmds/chaincode.js
+++ b/libraries/fabric-shim/test/unit/cmds/chaincode.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright contributors to Hyperledger Fabric.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* global describe it beforeEach afterEach */

--- a/libraries/fabric-shim/test/unit/contract-spi/bootstrap.js
+++ b/libraries/fabric-shim/test/unit/contract-spi/bootstrap.js
@@ -1,16 +1,9 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright contributors to Hyperledger Fabric.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 /* global describe it beforeEach afterEach after */
 /* eslint-disable no-console */
 'use strict';

--- a/libraries/fabric-shim/test/unit/contract-spi/chaincodefromcontract.js
+++ b/libraries/fabric-shim/test/unit/contract-spi/chaincodefromcontract.js
@@ -1,16 +1,9 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright contributors to Hyperledger Fabric.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 /* global describe it beforeEach afterEach */
 'use strict';
 

--- a/libraries/fabric-shim/test/unit/contract-spi/datamarshall.js
+++ b/libraries/fabric-shim/test/unit/contract-spi/datamarshall.js
@@ -1,15 +1,7 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* global describe it beforeEach afterEach  */

--- a/libraries/fabric-shim/test/unit/contract-spi/systemcontract.js
+++ b/libraries/fabric-shim/test/unit/contract-spi/systemcontract.js
@@ -1,16 +1,9 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Copyright IBM Corp. All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 /* global describe it beforeEach afterEach  */
 'use strict';
 

--- a/libraries/fabric-shim/test/unit/utils/utils.js
+++ b/libraries/fabric-shim/test/unit/utils/utils.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const chai = require('chai');
 const expect = chai.expect;
 

--- a/test/chaincodes/clientidentity/index.js
+++ b/test/chaincodes/clientidentity/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 const Chaincode = require('./chaincode');

--- a/test/chaincodes/crosschaincode/index.js
+++ b/test/chaincodes/crosschaincode/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 const Chaincode = require('./chaincode');

--- a/test/chaincodes/crud/index.js
+++ b/test/chaincodes/crud/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 const Chaincode = require('./chaincode');

--- a/test/chaincodes/encryption/index.js
+++ b/test/chaincodes/encryption/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 const Chaincode = require('./chaincode');

--- a/test/chaincodes/events/index.js
+++ b/test/chaincodes/events/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 const Chaincode = require('./chaincode');

--- a/test/chaincodes/ledger/index.js
+++ b/test/chaincodes/ledger/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 const Chaincode = require('./chaincode');

--- a/test/chaincodes/query/index.js
+++ b/test/chaincodes/query/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 const Chaincode = require('./chaincode');

--- a/test/chaincodes/scenario/index.js
+++ b/test/chaincodes/scenario/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 const UpdateValues = require('./updatevalues');

--- a/test/chaincodes/scenario/scenariocontext.js
+++ b/test/chaincodes/scenario/scenariocontext.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 const {Context} = require('fabric-contract-api');

--- a/test/chaincodes/scenario/updatevalues.js
+++ b/test/chaincodes/scenario/updatevalues.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 const {Contract} = require('fabric-contract-api');

--- a/tools/toolchain/index.js
+++ b/tools/toolchain/index.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright contributors to Hyperledger Fabric.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const {shell} = require('./shell/cmd');
 const {getTLSArgs, getPeerAddresses} = require('./utils');
 

--- a/tools/toolchain/utils.js
+++ b/tools/toolchain/utils.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright contributors to Hyperledger Fabric.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const path = require('path');
 
 const ordererCA = '/test-network/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem';


### PR DESCRIPTION
Fix link in SECURITY.md and add missing license and copyright notices.

To check, run repolinter --rulesetUrl https://github.com/hyperledger-labs/hyperledger-community-management-tools/raw/main/repo_structure/repolint.json

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>