### PR TITLE
Correct Typescript export

### DIFF
--- a/apis/fabric-contract-api/types/index.d.ts
+++ b/apis/fabric-contract-api/types/index.d.ts
@@ -12,7 +12,7 @@ declare module 'fabric-contract-api' {
     export class Context {
         stub: ChaincodeStub;
         clientIdentity: ClientIdentity;
-        logger: {
+        logging: {
             setLevel: (level: string) => void,
             getLogger: (name?: string) => Logger
         }


### PR DESCRIPTION
Logger in the Context type definition should be Logging

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>