### PR TITLE
Fix a dead link in docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 theme: minima
 title: "fabric-chaincode-node"
 releases:
-  - master
+  - main
   - release-1.4
   - release-2.2


### PR DESCRIPTION
A link is broken in the documentation page because
the name of the repository has been changed from master to main.
This PR fixes the dead link.

Signed-off-by: Nao Nishijima <nao.nishijima.xt@hitachi.com>