### PR TITLE
Chaincode errors should be returned as COMPLETED

### DIFF
--- a/libraries/fabric-shim/lib/contract-spi/chaincodefromcontract.js
+++ b/libraries/fabric-shim/lib/contract-spi/chaincodefromcontract.js
@@ -392,14 +392,14 @@ class ChaincodeFromContract {
                     await contractInstance.unknownTransaction(ctx);
                     return shim.success();
                 } catch (error) {
-                    return shim.error(error);
+                    return shim.error(error.message);
                 }
             }
 
         } catch (error) {
             // log the error and then fail the transaction
             logger.error(`${loggerPrefix} ${error.toString()}`);
-            return shim.error(error);
+            return shim.error(error.message);
         }
     }
 

--- a/libraries/fabric-shim/lib/handler.js
+++ b/libraries/fabric-shim/lib/handler.js
@@ -621,13 +621,13 @@ async function handleMessage(msg, client, action) {
                 resp.status));
 
             if (resp.status >= Stub.RESPONSE_CODE.ERROR) {
-                const errMsg = util.format('%s Calling chaincode %s() returned error response [%s]. Sending ERROR message back to peer',
+                const errMsg = util.format('%s Calling chaincode %s() returned error response [%s]. Sending COMPLETED message back to peer',
                     loggerPrefix, method, resp.message);
                 logger.error(errMsg);
 
                 nextStateMsg = {
-                    type: fabprotos.protos.ChaincodeMessage.Type.ERROR,
-                    payload: Buffer.from('' + resp.message),
+                    type: fabprotos.protos.ChaincodeMessage.Type.COMPLETED,
+                    payload: fabprotos.protos.Response.encode(resp).finish(),
                     txid: msg.txid,
                     channel_id: msg.channel_id
                 };

--- a/libraries/fabric-shim/test/unit/handler.js
+++ b/libraries/fabric-shim/test/unit/handler.js
@@ -1640,9 +1640,15 @@ describe('Handler', () => {
                 expect(mockHandler.chaincode.Init.firstCall.args[0]).to.deep.equal(mockStub);
 
                 const text = '[theChannelID-aTX] Calling chaincode Init() has not called success or error.';
-                expectedResponse.payload = Buffer.from(text);
+                const resp = {
+                    status: Stub.RESPONSE_CODE.ERROR,
+                    message: text
+                };
+                const payload = fabprotos.protos.Response.encode(resp).finish()
+                expectedResponse.type = fabprotos.protos.ChaincodeMessage.Type.COMPLETED;
+                expectedResponse.payload = payload;
                 expect(mockHandler._stream.write.calledOnce).to.be.true;
-                expect(mockHandler._stream.write.firstCall.args[0].payload.toString()).to.equal(text);
+                expect(mockHandler._stream.write.firstCall.args[0].payload).to.deep.equal(payload);
                 expect(mockHandler._stream.write.firstCall.args[0]).to.deep.equal(expectedResponse);
             });
 
@@ -1655,10 +1661,16 @@ describe('Handler', () => {
                 expect(mockHandler.chaincode.Invoke.calledOnce).to.be.true;
                 expect(mockHandler.chaincode.Invoke.firstCall.args[0]).to.deep.equal(mockStub);
                 const text = '[theChannelID-aTX] Calling chaincode Invoke() has not called success or error.';
-                expectedResponse.payload = Buffer.from(text);
+                const resp = {
+                    status: Stub.RESPONSE_CODE.ERROR,
+                    message: text
+                };
+                const payload = fabprotos.protos.Response.encode(resp).finish()
+                expectedResponse.type = fabprotos.protos.ChaincodeMessage.Type.COMPLETED;
+                expectedResponse.payload = payload;
                 expect(mockHandler._stream.write.calledOnce).to.be.true;
 
-                expect(mockHandler._stream.write.firstCall.args[0].payload.toString()).to.equal(text);
+                expect(mockHandler._stream.write.firstCall.args[0].payload).to.deep.equal(payload);
                 expect(mockHandler._stream.write.firstCall.args[0]).to.deep.equal(expectedResponse);
             });
 
@@ -1671,11 +1683,17 @@ describe('Handler', () => {
                 expect(mockHandler.chaincode.Init.calledOnce).to.be.true;
                 expect(mockHandler.chaincode.Init.firstCall.args[0]).to.deep.equal(mockStub);
                 const text = '[theChannelID-aTX] Calling chaincode Init() has not called success or error.';
-                expectedResponse.payload = Buffer.from(text);
+                const resp = {
+                    status: Stub.RESPONSE_CODE.ERROR,
+                    message: text
+                };
+                const payload = fabprotos.protos.Response.encode(resp).finish()
+                expectedResponse.type = fabprotos.protos.ChaincodeMessage.Type.COMPLETED;
+                expectedResponse.payload = payload;
 
                 expect(mockHandler._stream.write.calledOnce).to.be.true;
 
-                expect(mockHandler._stream.write.firstCall.args[0].payload.toString()).to.equal(text);
+                expect(mockHandler._stream.write.firstCall.args[0].payload).to.deep.equal(payload);
                 expect(mockHandler._stream.write.firstCall.args[0]).to.deep.equal(expectedResponse);
             });
 
@@ -1688,11 +1706,17 @@ describe('Handler', () => {
                 expect(mockHandler.chaincode.Invoke.calledOnce).to.be.true;
                 expect(mockHandler.chaincode.Invoke.firstCall.args[0]).to.deep.equal(mockStub);
                 const text = '[theChannelID-aTX] Calling chaincode Invoke() has not called success or error.';
-                expectedResponse.payload = Buffer.from(text);
+                const resp = {
+                    status: Stub.RESPONSE_CODE.ERROR,
+                    message: text
+                };
+                const payload = fabprotos.protos.Response.encode(resp).finish()
+                expectedResponse.type = fabprotos.protos.ChaincodeMessage.Type.COMPLETED;
+                expectedResponse.payload = payload;
 
                 expect(mockHandler._stream.write.calledOnce).to.be.true;
                 expect(mockHandler._stream.write.firstCall.args[0]).to.deep.equal(expectedResponse);
-                expect(mockHandler._stream.write.firstCall.args[0].payload.toString()).to.equal(text);
+                expect(mockHandler._stream.write.firstCall.args[0].payload).to.deep.equal(payload);
             });
         });
 

--- a/test/chaincodes/crosschaincode/chaincode.js
+++ b/test/chaincodes/crosschaincode/chaincode.js
@@ -38,14 +38,9 @@ class CrossChaincode extends Contract {
     }
 
     async invokeChaincodeError({stub}) {
-        let error;
         const {params} = stub.getFunctionAndParameters();
-        try {
-            await stub.invokeChaincode('crosschaincode2', [params[0]]);
-        } catch (err) {
-            error = err;
-        }
-        return error.message;
+        const results = await stub.invokeChaincode('crosschaincode2', [params[0]]);
+        return results;
     }
 
 }


### PR DESCRIPTION
The Node shim differs from the Go shim in that returns any chaincode generated errors as grpc errors.
In Go, it just returns the ProposalResponse message with a status 500 code and error message embedded in it.
This difference makes it hard to write consistent error handling code in Fabric (esp Gateway) and the SDKs.
This commit changes the Node shim error handler to behave the same as the Go shim.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>