### PR TITLE
Fix Doc: Type of args in invokeChaincode() is string[]

### DIFF
--- a/libraries/fabric-shim/lib/stub.js
+++ b/libraries/fabric-shim/lib/stub.js
@@ -730,7 +730,7 @@ class ChaincodeStub {
 	 * If `channel` is empty, the caller's channel is assumed.
 	 * @async
 	 * @param {string} chaincodeName Name of the chaincode to call
-	 * @param {byte[][]} args List of arguments to pass to the called chaincode
+	 * @param {string[]} args List of arguments to pass to the called chaincode
 	 * @param {string} channel Name of the channel where the target chaincode is active
 	 * @returns {Promise} Promise for a {@link Response} object returned by the called chaincode
 	 */


### PR DESCRIPTION
stub.invokeChaincode() receives a parameter `args` which is
a string array having arguments to pass to the called chaicode.
However, the current document explains the `args` is byte[][].
This PR fixes the document issue above.

Signed-off-by: Yuki Kondo <yuki.kondo.ob@hitachi.com>