### PR TITLE
Build failure - ignorable warning not ignored

### DIFF
--- a/apis/fabric-contract-api/package.json
+++ b/apis/fabric-contract-api/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "buildt": "tsc --project test/typescript",
-    "test": "nyc mocha --recursive 'test/unit/**/*.js'",
+    "test": "nyc mocha --recursive 'test/unit/**/*.js' 2>&1",
     "build": "npm run lint && npm run test:unit && npm run test:schema",
     "lint": "eslint ./lib/",
     "test:unit": "npm run test",

--- a/libraries/fabric-shim-crypto/package.json
+++ b/libraries/fabric-shim-crypto/package.json
@@ -9,7 +9,7 @@
         "url": "https://github.com/hyperledger/fabric-chaincode-node"
     },
     "scripts": {
-        "test": "nyc mocha --recursive 'test/**/*.js' --reporter spec-junit-splitter-mocha-reporter",
+        "test": "nyc mocha --recursive 'test/**/*.js' --reporter spec-junit-splitter-mocha-reporter 2>&1",
         "lint":"eslint ./lib/",
         "build": "npm run lint && npm test"
     },


### PR DESCRIPTION
Recent builds have failed with the browserlist module reporting
(on stderr) that it was outdated. This is a dependency of nyc, code coverage.

nyc is 'resting' and not actively being maintained.

Rush version used here is not ignoring that warning, and build fails.

Can't alter the rush rebuild command to ignore warnings. It's really
just going on anything written to stderr.

So adding a redirect on the nyc command stderr-> stdout (2>&1)
Have checked that a drop in coverage does still cause a failure.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>