### PR TITLE
Correct 2.4 to be Node 16

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,16 +2,15 @@
 
 Github is used for code base management, issues should reported in the [FABCN](https://jira.hyperledger.org/projects/FABCN/issues/) component in JIRA.
 
-
 ## Summary of Compatibility
 
 This table shows the summary of the compatibility of the Node modules at versions 1.4 and 2.x, together with the Nodejs runtime they require and the Fabric Peer versions they can communicate with.
 
-|                                | Peer Connectivity v1.4 | NodeJS | Peer Connectivity v2.x |
-| ------------------------------ | ---------------------- | ------ | ---------------------- |
-| Node modules **v1.4.5**        | Yes                    | 8      | Yes                    |
-| Node modules **v2.2.x/v2.3.x** | Yes                    | 12     | Yes                    |
-| Node modules **v2.4.x**        | Yes                    | 16     | Yes                    |
+|                                | Peer Connectivity v1.4 | Supported NodeJS | Peer Connectivity v2.x |
+| ------------------------------ | ---------------------- | ---------------- | ---------------------- |
+| Node modules **v1.4.5**        | Yes                    | 8                | Yes                    |
+| Node modules **v2.2.x/v2.3.x** | Yes                    | 12               | Yes                    |
+| Node modules **v2.4.x**        | Yes                    | 16               | Yes                    |
 
 By default a Fabric Peer v1.4 will create a Nodejs v8 runtime, and a Fabric Peer v2.2/2.3 will create a Nodejs 12 runtime. The Fabric v2.4 will create a Nodejs 16 runtime. Whilst these are defaults, the docker image used to host the chaincode and contracts can be altered. Set the environment variable `CORE_CHAINCODE_NODE_RUNTIME` on the peer to the name of the docker image.
 
@@ -19,7 +18,11 @@ For example `CORE_CHAINCODE_NODE_RUNTIME=hyperledger/fabric-nodeenv:2.1` will al
 
 The Node modules will connect to the peer whilst running; this is referred to as 'Fabric Peer Connectivity' in the table. For example, whilst the Fabric Peer v1.4 will create a Nodejs 8 runtime, if a Nodejs 12 runtime was configured, the node modules at v2.x still function when connecting to the Fabric Peer v1.4.
 
+### Version 1.4 compatibility with later Nodejs runtimes
+
 Note that the `fabric-contract-api` & `fabric-shim` node modules must be at v1.4.5 or greater to work with Node version 12. If you therefore use a contract originally written to work with Fabric 1.4, check the node modules before deploying on Fabric v2.
+
+Also please note that that the v1.4 libraries WILL NOT work with Node16. Unless you configure a different node environment, any chaincode using the v1.4 libraries will need to move to v2.4 before being able to run with a Fabric v2.4 Peer.
 
 ## Compatibility
 

--- a/docker/fabric-nodeenv/Dockerfile
+++ b/docker/fabric-nodeenv/Dockerfile
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-ARG NODE_VER=16.4.0
+ARG NODE_VER=16
 FROM node:${NODE_VER}-alpine
 RUN apk add --no-cache \
 	make \
-	python \
+	python3 \
 	g++;
 RUN mkdir -p /chaincode/input \
 	&& mkdir -p /chaincode/output \

--- a/docker/fabric-nodeenv/docker.js
+++ b/docker/fabric-nodeenv/docker.js
@@ -15,7 +15,6 @@ const util = require('util');
 const { shell: runcmds } = require('toolchain');
 
 const version = JSON.parse(fs.readFileSync(path.join(__dirname,'package.json'))).version;
-const node_version = process.env.NODE_VERSION || '12.16.1';
 const build_dir = path.join(__dirname);
 const tag = version + '-' + git.short();
 
@@ -23,8 +22,8 @@ const tag = version + '-' + git.short();
 const imageBuild = async () => {
     await runcmds(
         [
-            util.format('docker build --build-arg NODE_VER=%s -t hyperledger/fabric-nodeenv:%s -f %s %s',
-                node_version, tag, path.join(build_dir, 'Dockerfile'), build_dir),
+            util.format('docker build -t hyperledger/fabric-nodeenv:%s -f %s %s',
+                tag, path.join(build_dir, 'Dockerfile'), build_dir),
             util.format('docker tag hyperledger/fabric-nodeenv:%s hyperledger/fabric-nodeenv:%s',
                 tag, version),
             util.format('docker tag hyperledger/fabric-nodeenv:%s hyperledger/fabric-nodeenv:latest', tag)


### PR DESCRIPTION
Also update the compatibility to be clearer on the versions of node
that do not work.

Version 1.4 libraries will NOT work with node 16

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>