### PR TITLE
Allow jsdoc push to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v2.2.3
-Wed 27 Apr 2022 09:24:59 BST
+Thu 28 Apr 2022 09:44:19 BST
 
 * [437c67e](https://github.com/hyperledger/fabric-chaincode-node/commit/437c67e) Recent builds have failued with the browserlist module reporting (on stderr) that it was outdated. This is a dependency of nyc, code coverage.
 * [5311536](https://github.com/hyperledger/fabric-chaincode-node/commit/5311536) Rename the root json config file (#301)

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -264,6 +264,7 @@ stages:
                 git commit -m "Publishing GitHub Pages"
                 git push https://$(GITHUB-PAT)@github.com/hyperledger/fabric-chaincode-node.git gh-pages
               displayName: 'Commit gh-pages changes'
+              continueOnError: true # Need to fix jsdoc publishing after release
 
     # Publish a new version, triggered by a git tag
     - stage: Publish_tag


### PR DESCRIPTION
The jsdoc push to gh-pages is failing, possibly due to an expired GitHub PAT. Allow the step to fail for now in order to attempt another release.

Signed-off-by: James Taylor <jamest@uk.ibm.com>