### PR TITLE
Allow jsdoc push to fail

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -279,6 +279,7 @@ stages:
                 git commit -m "Publishing GitHub Pages"
                 git push https://$(GITHUB-PAT)@github.com/hyperledger/fabric-chaincode-node.git gh-pages
               displayName: 'Commit gh-pages changes'
+              continueOnError: true # Need to fix jsdoc publishing after release
 
     # Publish a new version, triggered by a git tag
     - stage: Publish_tag


### PR DESCRIPTION
The jsdoc push to gh-pages is failing, possibly due to an expired GitHub PAT. Allow the step to fail for now in order to release.

Signed-off-by: James Taylor <jamest@uk.ibm.com>