### PR TITLE
Add in short version docker tag

### DIFF
--- a/docker/fabric-nodeenv/docker.js
+++ b/docker/fabric-nodeenv/docker.js
@@ -18,6 +18,11 @@ const version = JSON.parse(fs.readFileSync(path.join(__dirname,'package.json')))
 const build_dir = path.join(__dirname);
 const tag = version + '-' + git.short();
 
+// reg exp the sort tag versions
+const regex = /^(\d+\.\d+)/
+const shortVersion = version.match(regex);
+
+
 // build and tag the fabric-nodeenv image
 const imageBuild = async () => {
     await runcmds(
@@ -26,6 +31,8 @@ const imageBuild = async () => {
                 tag, path.join(build_dir, 'Dockerfile'), build_dir),
             util.format('docker tag hyperledger/fabric-nodeenv:%s hyperledger/fabric-nodeenv:%s',
                 tag, version),
+            util.format('docker tag hyperledger/fabric-nodeenv:%s hyperledger/fabric-nodeenv:%s',
+                tag, shortVersion[shortVersion.index]),
             util.format('docker tag hyperledger/fabric-nodeenv:%s hyperledger/fabric-nodeenv:latest', tag)
         ]
 


### PR DESCRIPTION
Ideally we could adjust the docker image in the core.yaml but that is buried deep in the fabric-samples network.

Adding a short docker tag in the locally built docker image is the current best approach and simplest.
Should help the interopts testing

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>