### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,13 +1,20 @@
 Maintainers
 ===========
 
+**Active maintainers**
+
+| Name | GitHub | Chat | email
+|------|--------|------|-------
+| David Kelsey | [davidkel][davidkel] | davidkel | <d_kelsey@uk.ibm.com>
+| Matthew B White | [mbwhite][mbwhite] | mbwhite | <whitemat@uk.ibm.com>
+| James Taylor | [jt-nti][jt-nti] | jtonline | <jamest@uk.ibm.com>
+
+**Emeritus maintainers**
+
 | Name | GitHub | Chat | email
 |------|--------|------|-------
 | Andrew Hurt | [awjh-ibm][awjh-ibm] | awjh-ibm | <andrew.hurt1@ibm.com>
-| David Kelsey | [davidkel][davidkel] | davidkel | <d_kelsey@uk.ibm.com>
 | Bret Harrison | [harrisob][harrisob] | bretharrison | <beharrison@nc.rr.com>
-| Matthew B White | [mbwhite][mbwhite] | mbwhite | <whitemat@uk.ibm.com>
-| James Taylor | [jt-nti][jt-nti] | jtonline | <jamest@uk.ibm.com>
 | Chaoyi Zhao | [zhaochy1990][zhaochy1990] | zhaochy | <zhaochy_2015@hotmail.com>
 
 Also: Please see the [Release Manager section](https://github.com/hyperledger/fabric/blob/main/MAINTAINERS.md)


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>