### PR TITLE
Fix issues with server-mode

### DIFF
--- a/libraries/fabric-shim/lib/contract-spi/bootstrap.js
+++ b/libraries/fabric-shim/lib/contract-spi/bootstrap.js
@@ -29,7 +29,7 @@ class Bootstrap {
      * @ignore
      * @param {Contract} contracts contract to register to use
      */
-    static register(contracts, serializers, fileMetadata, title, version, opts, serverMode = false) {
+    static async register(contracts, serializers, fileMetadata, title, version, opts, serverMode = false) {
         // load up the meta data that the user may have specified
         // this will need to passed in and rationalized with the
         // code as implemented
@@ -37,7 +37,7 @@ class Bootstrap {
 
         if (serverMode) {
             const server = shim.server(chaincode, opts);
-            server.start();
+            await server.start();
         } else {
             // say hello to the peer
             shim.start(chaincode);
@@ -53,7 +53,7 @@ class Bootstrap {
         const opts = serverMode ? ServerCommand.getArgs(yargs) : StartCommand.getArgs(yargs);
         const {contracts, serializers, title, version} = this.getInfoFromContract(opts['module-path']);
         const fileMetadata = await Bootstrap.getMetadata(opts['module-path']);
-        Bootstrap.register(contracts, serializers, fileMetadata, title, version, opts, serverMode);
+        await Bootstrap.register(contracts, serializers, fileMetadata, title, version, opts, serverMode);
     }
 
     static getInfoFromContract(modulePath) {

--- a/libraries/fabric-shim/lib/handler.js
+++ b/libraries/fabric-shim/lib/handler.js
@@ -286,13 +286,13 @@ class ChaincodeMessageHandler {
         this.msgQueueHandler = new MsgQueueHandler(this);
 
         const stream = this._stream;
-        const self = this;
+
         // the conversation is supposed to follow a certain protocol,
         // if either side spoke out of turn, then we error out and
         // reject that response. The initial state is "created"
         let state = 'created';
 
-        stream.on('data', function (msgpb) {
+        stream.on('data', (msgpb) => {
             const msg = mapFromChaincodeMessage(msgpb);
             logger.debug(util.format('Received chat message from peer: %s, state: %s, type: %s', msg.txid, state, msg.type));
             if (state === STATES.Ready) {
@@ -304,13 +304,13 @@ class ChaincodeMessageHandler {
 
                     if (type === MSG_TYPE.RESPONSE || type === MSG_TYPE.ERROR) {
                         logger.debug(util.format('%s Received %s,  handling good or error response', loggerPrefix, msg.type));
-                        self.msgQueueHandler.handleMsgResponse(msg);
+                        this.msgQueueHandler.handleMsgResponse(msg);
                     } else if (type === MSG_TYPE.INIT) {
                         logger.debug(util.format('%s Received %s, initializing chaincode', loggerPrefix, msg.type));
-                        self.handleInit(msg);
+                        this.handleInit(msg);
                     } else if (type === MSG_TYPE.TRANSACTION) {
                         logger.debug(util.format('%s Received %s, invoking transaction on chaincode(state:%s)', loggerPrefix, msg.type, state));
-                        self.handleTransaction(msg);
+                        this.handleTransaction(msg);
                     } else {
                         logger.error('Received unknown message from the peer. Exiting.');
                         // TODO: Should we really do this ?
@@ -351,12 +351,12 @@ class ChaincodeMessageHandler {
             }
         });
 
-        stream.on('end', function () {
+        stream.on('end', () => {
             logger.debug('Chat stream ending');
             stream.cancel();
         });
 
-        stream.on('error', function (err) {
+        stream.on('error', (err) => {
             logger.error('Chat stream with peer - on error: %j', err.stack ? err.stack : err);
             stream.end();
         });

--- a/libraries/fabric-shim/lib/server.js
+++ b/libraries/fabric-shim/lib/server.js
@@ -95,11 +95,12 @@ class ChaincodeServer {
             const msgPb = new peer.ChaincodeID();
             msgPb.setName(this._serverOpts.ccid);
 
+            const registerMsg = new peer.ChaincodeMessage();
+            registerMsg.setType(peer.ChaincodeMessage.Type.REGISTER);
+            registerMsg.setPayload(msgPb.serializeBinary());
+
             logger.debug('Start chatting with a peer through a new stream. Chaincode ID = ' + this._serverOpts.ccid);
-            client.chat({
-                type: peer.ChaincodeMessage.Type.REGISTER,
-                payload: msgPb.serializeBinary()
-            });
+            client.chat(registerMsg);
         } catch (e) {
             logger.warn('connection from peer failed: ' + e);
         }

--- a/libraries/fabric-shim/test/unit/server.js
+++ b/libraries/fabric-shim/test/unit/server.js
@@ -198,10 +198,11 @@ describe('ChaincodeServer', () => {
             const payloadPb = new peer.ChaincodeID();
             payloadPb.setName('example-chaincode-id');
 
-            expect(mockHandler.chat.firstCall.args).to.deep.equal([{
-                type: peer.ChaincodeMessage.Type.REGISTER,
-                payload: payloadPb.serializeBinary()
-            }]);
+            const expectedResponse = new peer.ChaincodeMessage();
+            expectedResponse.setType(peer.ChaincodeMessage.Type.REGISTER);
+            expectedResponse.setPayload(payloadPb.serializeBinary());
+
+            expect(mapFromChaincodeMessage(mockHandler.chat.firstCall.args[0])).to.deep.equal(mapFromChaincodeMessage(expectedResponse));
         });
 
         it('should not throw even if chat fails', () => {
@@ -220,3 +221,14 @@ describe('ChaincodeServer', () => {
         });
     });
 });
+
+function mapFromChaincodeMessage(msgPb) {
+    return {
+        type: msgPb.getType(),
+        payload: Buffer.from(msgPb.getPayload_asU8()),
+        txid: msgPb.getTxid(),
+        channel_id: msgPb.getChannelId(),
+        proposal: msgPb.getProposal(),
+        chaincode_event: msgPb.getChaincodeEvent()
+    };
+}

--- a/libraries/fabric-shim/test/unit/stub.js
+++ b/libraries/fabric-shim/test/unit/stub.js
@@ -524,6 +524,7 @@ describe('Stub', () => {
             });
 
             it ('should throw Error if MSPID is not available', () => {
+                delete process.env.CORE_PEER_LOCALMSPID;
                 const stub = new Stub('dummyClient', 'dummyChannelId', 'dummyTxid', chaincodeInput);
 
                 expect(() => {


### PR DESCRIPTION
- removed possible issue with stream referring to the correct value, due to difference in scoping between function() and ()=>{}
- ensured that in server mode, the promise was awaited for
- fixed the register message being sent as the wrong type
- note the addition of the delete call - for some reason this was picked up by the coverage tests which it never has been before...


Signed-off-by: Matthew B White <whitemat@uk.ibm.com>