### PR TITLE
Backport merge from release-2.5 to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,13 +14,17 @@ on:
       - release-2.5
   create:
     tags:
-      - "*"      
+      - "v2.*"
   workflow_dispatch:
+
+env:
+  CHAINCODE_CONTAINER_NODE_VER: 16
+  DOCKER_REGISTRY: ${{ github.repository_owner == 'hyperledger' && 'docker.io' || 'ghcr.io' }}
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
-    outputs: 
+    runs-on: ubuntu-20.04
+    outputs:
       PACKAGE_VERSION: ${{ steps.builddata.outputs.PACKAGE_VERSION }}
       MINOR_PACKAGE_VERSION: ${{ steps.builddata.outputs.MINOR_PACKAGE_VERSION }}
       BUILD_DATE: ${{ steps.builddata.outputs.BUILD_DATE }}
@@ -34,12 +38,12 @@ jobs:
         run: |
           set -ex -o pipefail
           env | sort
-          
+
           # handle full version number
           VERSION=$(jq '.version' docker/fabric-nodeenv/package.json | sed -r "s/\"([0-9]?[0-9]\.[0-9]?[0-9]\.[0-9]?[0-9]).*/\1/")
           echo Current version in code is :${VERSION}:
           echo "PACKAGE_VERSION=${VERSION}" >> $GITHUB_OUTPUT
-          
+
           # handle minor version
           MINOR_VERSION=$(jq '.version' docker/fabric-nodeenv/package.json | sed -r "s/\"([0-9]?[0-9]\.[0-9]?[0-9])\.[0-9]?[0-9].*/\1/")
           echo Current minor version in code is :${MINOR_VERSION}:
@@ -51,7 +55,7 @@ jobs:
           echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_OUTPUT
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [16.x]
@@ -61,7 +65,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}    
+          node-version: ${{ matrix.node-version }}
       - name: Install/Rebuild/UnitTest
         run: |
           set -xev
@@ -71,7 +75,7 @@ jobs:
         run: |
           npx cobertura-merge -o merged_coverage.xml shim=./libraries/fabric-shim/coverage/cobertura-coverage.xml contractapi=./apis/fabric-contract-api/coverage/cobertura-coverage.xml -p
       - uses: actions/upload-artifact@v3
-        name: Upload test results      
+        name: Upload test results
         if: success() || failure()
         with:
           name: TestResults
@@ -96,7 +100,7 @@ jobs:
           path: fabric-nodeenv.tar.gz
 
   fvtest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [build]
     strategy:
       matrix:
@@ -106,7 +110,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}    
+          node-version: ${{ matrix.node-version }}
 
       - uses: actions/download-artifact@v3
         with:
@@ -136,10 +140,10 @@ jobs:
           set -xev
           export TLS=true
           docker images | grep hyperledger && docker ps -a
-          
+
           node common/scripts/install-run-rush.js test:fv --verbose
           node common/scripts/install-run-rush.js test:e2e --verbose
-    
+
 
       - uses: actions/upload-artifact@v3
         if: success() || failure()
@@ -154,7 +158,7 @@ jobs:
         # Pulling in all the dependencies it will be able to run NPM AUDIT, and if that returns a
         # error code the job will fail.
   src_audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build
     strategy:
       matrix:
@@ -164,7 +168,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}   
+          node-version: ${{ matrix.node-version }}
       - uses: actions/download-artifact@v3
         with:
           name: node-tgzs
@@ -179,7 +183,7 @@ jobs:
           npm audit --audit-level=moderate
 
   publishnpm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [build,fvtest,src_audit]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -190,7 +194,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: node-tgzs
-          path: build/          
+          path: build/
       - run: |
           set -xev
           ls -lart build/
@@ -201,37 +205,54 @@ jobs:
 
 
   publishdocker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [setup,build,fvtest,src_audit]
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16.x'
-      - uses: actions/download-artifact@v3
-        with:
-          name: nodeenv-docker-image
-          path: build/          
-      - name: Push to registry
-        run: |
-          set -xev
-          wget -qO "$PWD/manifest-tool" https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64
-          chmod +x ./manifest-tool
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-          echo "Version strings are ${PACKAGE_VERSION} ${MINOR_PACKAGE_VERSION}"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 1
 
-          docker image load --input build/fabric-javaenv.tar.gz
-          docker images
-          docker login ${DOCKER_REGISTRY_URL} --username=${DOCKER_REGISTRY_USERNAME} --password=${DOCKER_REGISTRY_PASSWORD}
-          echo "Logged in to docker registry"
-          # tag javaenv image to PACKAGE_VERSION
-          docker tag hyperledger/fabric-javaenv hyperledger/fabric-nodeenv:amd64-${ PACKAGE_VERSION }
-          # push javaenv to repository
-          docker push hyperledger/fabric-javaenv:amd64-${ PACKAGE_VERSION }
-          ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-nodeenv:amd64-${ PACKAGE_VERSION }" --target "hyperledger/fabric-nodeenv:${ PACKAGE_VERSION }"
-          ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-nodeenv:amd64-${ PACKAGE_VERSION }" --target "hyperledger/fabric-nodeenv:${ MINOR_PACKAGE_VERSION }"
-        env:
-          DOCKER_REGISTRY_USERNAME:  ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKER_REGISTRY_PASSWORD:  ${{ secrets.DOCKERHUB_TOKEN }}      
-          PACAKGE_VERSION: ${{  needs.setup.outputs.PACKAGE_VERSION }}
-          MINOR_PACKAGE_VERSION: ${{ needs.setup.outputs.MINOR_PACKAGE_VERSION }}
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Login to the ${{ env.DOCKER_REGISTRY }} Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ env.DOCKER_REGISTRY == 'docker.io' && secrets.DOCKERHUB_USERNAME || github.actor }}
+          password: ${{ env.DOCKER_REGISTRY == 'docker.io' && secrets.DOCKERHUB_TOKEN    || secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/fabric-nodeenv
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+
+      - name: Build and push ${{ matrix.COMPONENT }} Image
+        id: push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+          file: docker/fabric-nodeenv/Dockerfile
+          context: docker/fabric-nodeenv
+          tags: ${{ steps.meta.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NODE_VER=${{ env.CHAINCODE_CONTAINER_NODE_VER }}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.3
 
 specifiers:
   '@fidm/x509': ^1.2.1
-  '@grpc/grpc-js': ^1.4.1
+  '@grpc/grpc-js': 1.8.1
   '@grpc/proto-loader': ^0.6.6
   '@hyperledger/fabric-protos': 0.1.0-dev.2300102001.1
   '@rush-temp/fabric-contract-api': file:./projects/fabric-contract-api.tgz
@@ -68,7 +68,7 @@ specifiers:
 
 dependencies:
   '@fidm/x509': 1.2.1
-  '@grpc/grpc-js': 1.6.7
+  '@grpc/grpc-js': 1.8.1
   '@grpc/proto-loader': 0.6.11
   '@hyperledger/fabric-protos': 0.1.0-dev.2300102001.1
   '@rush-temp/fabric-contract-api': file:projects/fabric-contract-api.tgz
@@ -390,11 +390,11 @@ packages:
       tweetnacl: 1.0.3
     dev: false
 
-  /@grpc/grpc-js/1.6.7:
-    resolution: {integrity: sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==}
+  /@grpc/grpc-js/1.8.1:
+    resolution: {integrity: sha512-mdqYADWl/9Kb75XLstt6pvBnS1DpxSDFRKrbadkY1ymUd29hq49nP6tLcL7a7qLydgqFCpjNwa2RsyrqB3MsXA==}
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
-      '@grpc/proto-loader': 0.6.11
+      '@grpc/proto-loader': 0.7.4
       '@types/node': 16.11.33
     dev: false
 
@@ -407,6 +407,18 @@ packages:
       lodash.camelcase: 4.3.0
       long: 5.2.0
       protobufjs: 6.11.2
+      yargs: 16.2.0
+    dev: false
+
+  /@grpc/proto-loader/0.7.4:
+    resolution: {integrity: sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dependencies:
+      '@types/long': 4.0.2
+      lodash.camelcase: 4.3.0
+      long: 4.0.0
+      protobufjs: 7.1.2
       yargs: 16.2.0
     dev: false
 
@@ -428,7 +440,7 @@ packages:
   /@hyperledger/fabric-protos/0.1.0-dev.2300102001.1:
     resolution: {integrity: sha512-MtVXncAQz09PYOcFZUB2QbS9eVwbSGnULPuZKqFr9iScbasG194QyN6Tq8cl+kthQGSoBQORyjCIbrGIaN8EFQ==}
     dependencies:
-      '@grpc/grpc-js': 1.6.7
+      '@grpc/grpc-js': 1.8.1
       '@types/google-protobuf': 3.15.6
       google-protobuf: 3.20.1
     dev: false
@@ -5509,6 +5521,25 @@ packages:
       long: 4.0.0
     dev: false
 
+  /protobufjs/7.1.2:
+    resolution: {integrity: sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==}
+    engines: {node: '>=12.0.0'}
+    requiresBuild: true
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 16.11.33
+      long: 5.2.0
+    dev: false
+
   /pseudomap/1.0.2:
     resolution: {integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=}
     dev: false
@@ -7215,7 +7246,7 @@ packages:
     dev: false
 
   file:projects/fabric-contract-api.tgz:
-    resolution: {integrity: sha512-eVrQePOmEB52yrz1kzKn4c4xMXFVE1m23QLrTAjEiXHNVijgfoQU5Eecu5lXldLaqd1bqw6DbosfUWQq0h/NPg==, tarball: file:projects/fabric-contract-api.tgz}
+    resolution: {integrity: sha512-WeRli7QZ/qurpPhdLWQZKxqbjCuenMqk/erhPXqQj+8ntVeuujmjpHcd7ni/x36f2QkRcFymgoWg40AMBAkZaQ==, tarball: file:projects/fabric-contract-api.tgz}
     name: '@rush-temp/fabric-contract-api'
     version: 0.0.0
     dependencies:
@@ -7244,7 +7275,7 @@ packages:
     dev: false
 
   file:projects/fabric-e2e-tests.tgz:
-    resolution: {integrity: sha512-MJV7kL0chXgfn8YGmP2MVAr1fAKgFjjW3PPnIl5yiM2D2qbBtq0SPn0mTGfWLHaNfaq7cWlz6MlKVSUambixjg==, tarball: file:projects/fabric-e2e-tests.tgz}
+    resolution: {integrity: sha512-bp7LbwT1KA55tQSq+OrLnGIgb+IzJJBZKamXFuvH4hDxYU4TJS5F4IYmaUEhn+cezZYvaEY/JtAMjzh6eEQaVA==, tarball: file:projects/fabric-e2e-tests.tgz}
     name: '@rush-temp/fabric-e2e-tests'
     version: 0.0.0
     dependencies:
@@ -7259,7 +7290,7 @@ packages:
     dev: false
 
   file:projects/fabric-ledger.tgz_@types+node@16.11.33:
-    resolution: {integrity: sha512-qrh68IOywmd+7/iH5NSdbv98bsFFnaSxUsWb1J6exAC93we2r3KhhxC8hJ8Co6IIBTgDeMNrIfqpcsYGXkxOpQ==, tarball: file:projects/fabric-ledger.tgz}
+    resolution: {integrity: sha512-BnwvvJqQ1EqwZEDvdqVtRYATLS5V0pO+ghFjPodUswCSH9ZvSaxSMLi7y2bfCcXi3S3PsxGjGRklAhiEA+8PYg==, tarball: file:projects/fabric-ledger.tgz}
     id: file:projects/fabric-ledger.tgz
     name: '@rush-temp/fabric-ledger'
     version: 0.0.0
@@ -7291,7 +7322,7 @@ packages:
     dev: false
 
   file:projects/fabric-nodeenv.tgz:
-    resolution: {integrity: sha512-h5gIjzgJZB2RqHo12lO3TISyBZoJeAlDCZgZaG9mPSULdOxi6NPoMT7OdbQVIoXR0BEOehPu37iD/k1y1IQrCg==, tarball: file:projects/fabric-nodeenv.tgz}
+    resolution: {integrity: sha512-2xlHPeg7Ai19lR/DZmXF6VgDCOXXAahx6vl6qGf5D5qCEeskNz2sC1xbDplhQ6kTndeUG+WAmAuVcHL2vwo7kA==, tarball: file:projects/fabric-nodeenv.tgz}
     name: '@rush-temp/fabric-nodeenv'
     version: 0.0.0
     dependencies:
@@ -7307,7 +7338,7 @@ packages:
     dev: false
 
   file:projects/fabric-shim-docs.tgz:
-    resolution: {integrity: sha512-/qwuSaN2n9+BIz5RF2TYAcJZ83uCWt0CKvW9mJRa5HP3hZb/jUkB+NA1bX4r0J+c+LvPF2yPaj7JlCY3LvqMpg==, tarball: file:projects/fabric-shim-docs.tgz}
+    resolution: {integrity: sha512-jOYtRlpdPlAvXoTZMDrte9nruyqobBOsDK6ALZqMkAHWpnwK/kChQ0oT+jtUjiVwLfW3Mx3NDf3b9Nqd+7tOwA==, tarball: file:projects/fabric-shim-docs.tgz}
     name: '@rush-temp/fabric-shim-docs'
     version: 0.0.0
     dependencies:
@@ -7317,12 +7348,12 @@ packages:
     dev: false
 
   file:projects/fabric-shim.tgz:
-    resolution: {integrity: sha512-WS27rJkyhhUcxueHdOiF5R0iJlXQPPtkoSP08dEAYPcF39QB/rTRtLp7YGsS8Vr2spQqRM6UF5aGiJPZsECFpw==, tarball: file:projects/fabric-shim.tgz}
+    resolution: {integrity: sha512-iAReiPzm4SAg32FRjn2c+0B+dgV6xvOa717uq2CyE9cOVGzBepnA5m3p6AoD/ITZxuOBWm79E5iLxCjgnekscw==, tarball: file:projects/fabric-shim.tgz}
     name: '@rush-temp/fabric-shim'
     version: 0.0.0
     dependencies:
       '@fidm/x509': 1.2.1
-      '@grpc/grpc-js': 1.6.7
+      '@grpc/grpc-js': 1.8.1
       '@grpc/proto-loader': 0.6.11
       '@hyperledger/fabric-protos': 0.1.0-dev.2300102001.1
       '@types/node': 16.11.33
@@ -7350,7 +7381,7 @@ packages:
     dev: false
 
   file:projects/fvtests.tgz:
-    resolution: {integrity: sha512-wgaAo/UdcN0T+3iNh6lmSOllruZYI55QW+wmnLE4qLNRL1CW5Akcs7h+JDuhH8IPK5CHWuR/Egsij2J7Hvg9kA==, tarball: file:projects/fvtests.tgz}
+    resolution: {integrity: sha512-zQbaPJ0nbq66+36UAkCGkclKySVzOpxEugaXgJo4MaypYhXBFacoQfxlIN8NqqRDP7n1FSienIehRAdbC9VC0Q==, tarball: file:projects/fvtests.tgz}
     name: '@rush-temp/fvtests'
     version: 0.0.0
     dependencies:

--- a/libraries/fabric-shim/lib/contract-spi/bootstrap.js
+++ b/libraries/fabric-shim/lib/contract-spi/bootstrap.js
@@ -29,7 +29,7 @@ class Bootstrap {
      * @ignore
      * @param {Contract} contracts contract to register to use
      */
-    static register(contracts, serializers, fileMetadata, title, version, opts, serverMode = false) {
+    static async register(contracts, serializers, fileMetadata, title, version, opts, serverMode = false) {
         // load up the meta data that the user may have specified
         // this will need to passed in and rationalized with the
         // code as implemented
@@ -37,7 +37,7 @@ class Bootstrap {
 
         if (serverMode) {
             const server = shim.server(chaincode, opts);
-            server.start();
+            await server.start();
         } else {
             // say hello to the peer
             shim.start(chaincode);
@@ -53,7 +53,7 @@ class Bootstrap {
         const opts = serverMode ? ServerCommand.getArgs(yargs) : StartCommand.getArgs(yargs);
         const {contracts, serializers, title, version} = this.getInfoFromContract(opts['module-path']);
         const fileMetadata = await Bootstrap.getMetadata(opts['module-path']);
-        Bootstrap.register(contracts, serializers, fileMetadata, title, version, opts, serverMode);
+        await Bootstrap.register(contracts, serializers, fileMetadata, title, version, opts, serverMode);
     }
 
     static getInfoFromContract(modulePath) {

--- a/libraries/fabric-shim/lib/handler.js
+++ b/libraries/fabric-shim/lib/handler.js
@@ -286,13 +286,13 @@ class ChaincodeMessageHandler {
         this.msgQueueHandler = new MsgQueueHandler(this);
 
         const stream = this._stream;
-        const self = this;
+
         // the conversation is supposed to follow a certain protocol,
         // if either side spoke out of turn, then we error out and
         // reject that response. The initial state is "created"
         let state = 'created';
 
-        stream.on('data', function (msgpb) {
+        stream.on('data', (msgpb) => {
             const msg = mapFromChaincodeMessage(msgpb);
             logger.debug(util.format('Received chat message from peer: %s, state: %s, type: %s', msg.txid, state, msg.type));
             if (state === STATES.Ready) {
@@ -304,13 +304,13 @@ class ChaincodeMessageHandler {
 
                     if (type === MSG_TYPE.RESPONSE || type === MSG_TYPE.ERROR) {
                         logger.debug(util.format('%s Received %s,  handling good or error response', loggerPrefix, msg.type));
-                        self.msgQueueHandler.handleMsgResponse(msg);
+                        this.msgQueueHandler.handleMsgResponse(msg);
                     } else if (type === MSG_TYPE.INIT) {
                         logger.debug(util.format('%s Received %s, initializing chaincode', loggerPrefix, msg.type));
-                        self.handleInit(msg);
+                        this.handleInit(msg);
                     } else if (type === MSG_TYPE.TRANSACTION) {
                         logger.debug(util.format('%s Received %s, invoking transaction on chaincode(state:%s)', loggerPrefix, msg.type, state));
-                        self.handleTransaction(msg);
+                        this.handleTransaction(msg);
                     } else {
                         logger.error('Received unknown message from the peer. Exiting.');
                         // TODO: Should we really do this ?
@@ -351,12 +351,12 @@ class ChaincodeMessageHandler {
             }
         });
 
-        stream.on('end', function () {
+        stream.on('end', () => {
             logger.debug('Chat stream ending');
             stream.cancel();
         });
 
-        stream.on('error', function (err) {
+        stream.on('error', (err) => {
             logger.error('Chat stream with peer - on error: %j', err.stack ? err.stack : err);
             stream.end();
         });

--- a/libraries/fabric-shim/lib/server.js
+++ b/libraries/fabric-shim/lib/server.js
@@ -95,11 +95,12 @@ class ChaincodeServer {
             const msgPb = new peer.ChaincodeID();
             msgPb.setName(this._serverOpts.ccid);
 
+            const registerMsg = new peer.ChaincodeMessage();
+            registerMsg.setType(peer.ChaincodeMessage.Type.REGISTER);
+            registerMsg.setPayload(msgPb.serializeBinary());
+
             logger.debug('Start chatting with a peer through a new stream. Chaincode ID = ' + this._serverOpts.ccid);
-            client.chat({
-                type: peer.ChaincodeMessage.Type.REGISTER,
-                payload: msgPb.serializeBinary()
-            });
+            client.chat(registerMsg);
         } catch (e) {
             logger.warn('connection from peer failed: ' + e);
         }

--- a/libraries/fabric-shim/package.json
+++ b/libraries/fabric-shim/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fidm/x509": "^1.2.1",
-    "@grpc/grpc-js": "^1.4.1",
+    "@grpc/grpc-js": "1.8.1",
     "@grpc/proto-loader": "^0.6.6",
     "@hyperledger/fabric-protos": "0.1.0-dev.2300102001.1",
     "@types/node": "^16.11.1",

--- a/libraries/fabric-shim/test/unit/server.js
+++ b/libraries/fabric-shim/test/unit/server.js
@@ -198,10 +198,11 @@ describe('ChaincodeServer', () => {
             const payloadPb = new peer.ChaincodeID();
             payloadPb.setName('example-chaincode-id');
 
-            expect(mockHandler.chat.firstCall.args).to.deep.equal([{
-                type: peer.ChaincodeMessage.Type.REGISTER,
-                payload: payloadPb.serializeBinary()
-            }]);
+            const expectedResponse = new peer.ChaincodeMessage();
+            expectedResponse.setType(peer.ChaincodeMessage.Type.REGISTER);
+            expectedResponse.setPayload(payloadPb.serializeBinary());
+
+            expect(mapFromChaincodeMessage(mockHandler.chat.firstCall.args[0])).to.deep.equal(mapFromChaincodeMessage(expectedResponse));
         });
 
         it('should not throw even if chat fails', () => {
@@ -220,3 +221,14 @@ describe('ChaincodeServer', () => {
         });
     });
 });
+
+function mapFromChaincodeMessage(msgPb) {
+    return {
+        type: msgPb.getType(),
+        payload: Buffer.from(msgPb.getPayload_asU8()),
+        txid: msgPb.getTxid(),
+        channel_id: msgPb.getChannelId(),
+        proposal: msgPb.getProposal(),
+        chaincode_event: msgPb.getChaincodeEvent()
+    };
+}

--- a/libraries/fabric-shim/test/unit/stub.js
+++ b/libraries/fabric-shim/test/unit/stub.js
@@ -524,6 +524,7 @@ describe('Stub', () => {
             });
 
             it ('should throw Error if MSPID is not available', () => {
+                delete process.env.CORE_PEER_LOCALMSPID;
                 const stub = new Stub('dummyClient', 'dummyChannelId', 'dummyTxid', chaincodeInput);
 
                 expect(() => {


### PR DESCRIPTION
This PR cherry-picks commits from release-2.5 to main: 

- 30125f689a872073a2c37d6c64cd683b04acd754 (Build multi-arch / arm64 hyperledger/fabric-nodeenv) 
- b35dee8d9eb574649889c02c96775c5781a7c1d2 (Pin grpc-js to 1.8.1) 
- 0bd21b79bab7b3e5b89f8f0c908b4e6f7aed72f4 (Update to use arrow functions)
