### PR TITLE
Fix the handling of the key endorsement policy

### DIFF
--- a/libraries/fabric-shim/lib/utils/statebased.js
+++ b/libraries/fabric-shim/lib/utils/statebased.js
@@ -132,10 +132,14 @@ class KeyEndorsementPolicy {
             sigsPolicies.push(signedBy);
         });
 
-        const policy = new common.SignaturePolicy();
+
+        // Need to say that we want all of the mspIDs from the list.
         const nOutOf = new common.SignaturePolicy.NOutOf();
         nOutOf.setN(mspIds.length);
         nOutOf.setRulesList(sigsPolicies);
+
+        const policy = new common.SignaturePolicy();
+        policy.setNOutOf(nOutOf);
 
         spe.setIdentitiesList(principals);
         spe.setRule(policy);

--- a/libraries/fabric-shim/test/unit/utils/statebased.js
+++ b/libraries/fabric-shim/test/unit/utils/statebased.js
@@ -4,9 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 */
 
-
-// const rewire = require('rewire');
-
+const { msp, common } = require('@hyperledger/fabric-protos');
+const { SignedProposal } = require('@hyperledger/fabric-protos/lib/peer');
 const chai = require('chai');
 const expect = chai.expect;
 const KeyEndorsementPolicy = require('../../../lib/utils/statebased');
@@ -106,9 +105,34 @@ describe('KeyEndorsementPolicy', () => {
         it('should successfully get policy', () => {
             const policy = ep.getPolicy();
             const anotherEp = new KeyEndorsementPolicy(policy);
-            expect(anotherEp.orgs).to.haveOwnProperty('Org1MSP');
-            expect(anotherEp.orgs).to.haveOwnProperty('Org2MSP');
-            expect(anotherEp.orgs).to.haveOwnProperty('Org3MSP');
+
+            const spe = common.SignaturePolicyEnvelope.deserializeBinary(policy);
+            const speClone = common.SignaturePolicyEnvelope.deserializeBinary(anotherEp.getPolicy());
+            expect(spe.toObject()).to.deep.equals(speClone.toObject());
+        });
+
+
+        it('should get policy that is semantically valid', () => {
+            const policy = ep.getPolicy();
+            const spe = common.SignaturePolicyEnvelope.deserializeBinary(policy);
+
+            // create a blank object and expand all the protobufs into it
+            const speObject = spe.toObject();
+
+            speObject.identitiesList = spe.getIdentitiesList().map(principal => {
+                let mapped = { principalClassification: 0 };
+                mapped.principal = msp.MSPRole.deserializeBinary(principal.getPrincipal_asU8()).toObject();
+                return mapped;
+            });            
+
+            speObject.rule.nOutOf.rulesList = spe.getRule().getNOutOf().getRulesList().map(sigRule =>{
+                 return {signedBy: sigRule.getSignedBy()}
+            });
+
+            const expectedPolicy={"version":0,"rule":{"signedBy":0,"nOutOf":{"n":3,"rulesList":[{"signedBy":0},{"signedBy":1},{"signedBy":2}]}},"identitiesList":[{"principalClassification":0,"principal":{"mspIdentifier":"Org1MSP","role":0}},{"principalClassification":0,"principal":{"mspIdentifier":"Org2MSP","role":0}},{"principalClassification":0,"principal":{"mspIdentifier":"Org3MSP","role":0}}]}
+            expect(speObject).to.deep.equals(expectedPolicy);
         });
     });
 });
+
+


### PR DESCRIPTION
The nOutOf was missing.

'specifically' this line wasn't there before... 

```
policy.setNOutOf(nOutOf);
```

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>