### PR TITLE
Update COMPATIBILITY.md for Node 18.

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,40 +1,45 @@
 # Support and Compatibility for fabric-chaincode-node
 
-Github is used for code base management, issues should reported in the [FABCN](https://jira.hyperledger.org/projects/FABCN/issues/) component in JIRA.
+Github is used for code base management, issues should reported in the repository's [GitHub Issues](https://github.com/hyperledger/fabric-chaincode-node/issues).
 
 ## Summary of Compatibility
 
-This table shows the summary of the compatibility of the Node modules at versions 1.4 and 2.x, together with the Nodejs runtime they require and the Fabric Peer versions they can communicate with.
+This table shows the summary of the compatibility of the Node modules at versions 1.4 and 2.x, together with the Node.js runtime they require and the Fabric Peer versions they can communicate with.
 
 |                                | Peer Connectivity v1.4 | Supported NodeJS | Peer Connectivity v2.x |
 | ------------------------------ | ---------------------- | ---------------- | ---------------------- |
 | Node modules **v1.4.5**        | Yes                    | 8                | Yes                    |
 | Node modules **v2.2.x/v2.3.x** | Yes                    | 12               | Yes                    |
 | Node modules **v2.4.x**        | Yes                    | 16               | Yes                    |
-| Node modules **v2.5.x**        | Yes                    | 16               | Yes                    |
+| Node modules **v2.5.x**        | Yes                    | 18               | Yes                    |
 
 
-By default a Fabric Peer v1.4 will create a Nodejs v8 runtime, and a Fabric Peer v2.2/2.3 will create a Nodejs 12 runtime. The Fabric v2.5 will create a Nodejs 16 runtime. Whilst these are defaults, the docker image used to host the chaincode and contracts can be altered. Set the environment variable `CORE_CHAINCODE_NODE_RUNTIME` on the peer to the name of the docker image.
+* Fabric peer v1.4 will create a Node.js v8 runtime
+* Fabric peer v2.2/2.3 will create a Node.js 12 runtime
+* Fabric peer v2.4 will create a Node.js 16 runtime
+* Fabric peer v2.5 will create a Node.js 18 runtime
 
-For example `CORE_CHAINCODE_NODE_RUNTIME=hyperledger/fabric-nodeenv:2.1` will allow the use of the latest Node 12 runtime to be used within a Peer v1.4.
+Whilst these are defaults based on the corresponding `fabric-nodeenv` docker image version, the docker image used to host the chaincode and contracts can be altered. Set the environment variable `CORE_CHAINCODE_NODE_RUNTIME` on the peer to the name of the desired docker image and version.
 
-The Node modules will connect to the peer whilst running; this is referred to as 'Fabric Peer Connectivity' in the table. For example, whilst the Fabric Peer v1.4 will create a Nodejs 8 runtime, if a Nodejs 12 runtime was configured, the node modules at v2.x still function when connecting to the Fabric Peer v1.4.
+For example `CORE_CHAINCODE_NODE_RUNTIME=hyperledger/fabric-nodeenv:2.2` will allow the use of the latest Node 12 runtime to be used within a Peer v1.4.
 
-### Version 1.4 compatibility with later Nodejs runtimes
+The Node chaincode modules will connect to the peer whilst running; this is referred to as 'Fabric Peer Connectivity' in the table. For example, whilst the Fabric Peer v1.4 will create a Node.js 8 runtime, if a Node.js 12 runtime was configured, the node chaincode modules at v2.x still function when connecting to the Fabric Peer v1.4.
 
-Note that the `fabric-contract-api` & `fabric-shim` node modules must be at v1.4.5 or greater to work with Node version 12. If you therefore use a contract originally written to work with Fabric 1.4, check the node modules before deploying on Fabric v2.
+### Version 1.4 compatibility with later Node.js runtimes
 
-Also please note that that the v1.4 libraries WILL NOT work with Node16. Unless you configure a different node environment, any chaincode using the v1.4 libraries will need to move to v2.5 before being able to run with a Fabric v2.4 Peer.
+Note that the `fabric-contract-api` & `fabric-shim` node modules must be at v1.4.5 or greater to work with Node.js version 12. If you therefore use a contract originally written to work with Fabric 1.4, check the node modules before deploying on Fabric v2.
+
+Also please note that that the v1.4 libraries WILL NOT work with Node.js 16 or Node.js 18. Unless you configure a different node environment, any chaincode using the v1.4 node chaincode libraries will need to update to the v2.5 node chaincode libraries before being able to run with a Fabric v2.5 Peer.
 
 ## Compatibility
 
 The key elements are :
 
 - the version of the Fabric Contract Node modules used
-- the version of the Nodejs runtime used to run the code
+- the version of the Node.js runtime used to run the code
 - When starting a chaincode container to run a Smart Contract, the version of the runtime that is used is determined by these factors:
 
-Fabric v1.4.2, and Fabric v2.x will, by default, start up docker image to host the chaincode and contracts. The version of the docker image used is defined by the version of Fabric in use.
+Fabric v1.4.x, and Fabric v2.x will, by default, start up a docker container based on `fabric-nodeenv` to host the chaincode and contracts. The version of the docker image used is driven by the version of Fabric in use, but can be overridden by setting the peer's `CORE_CHAINCODE_NODE_RUNTIME` environment variable.
 
 With Fabric v2.x, the chaincode container can be configured to be started by other means, and not the Peer. In this case, the environment used is not in the control of Fabric.
 
@@ -42,22 +47,23 @@ Node modules that are produced are `fabric-contract-api`, `fabric-shim` & `fabri
 
 ### Supported Runtimes
 
-v2.4 Node modules are supported running in Nodejs 16.4.0, with the x86_64 architecture.
-
-v2.2/2.3 Node modules are supported running in Nodejs 12.16.1, with the x86_64 architecture.
-
-v1.4.x Node modules are supported running Nodejs 8.16.1 with the x86_64 architecture.
+* Fabric v1.4 Node.js chaincode modules are supported running Nodejs 8.16.1 with the x86_64 architecture.
+* Fabric v2.2/v2.3 Node.js chaincode modules are supported running in Node.js 12.22.6, with the x86_64 architecture.
+* Fabric v2.4 Node.js chaincode modules are supported running in Node.js 16.x, with the x86_64 architecture.
+* Fabric v2.5 Node.js chaincode modules are supported running in Node.js 18.x, with the x86_64 and arm64 architectures.
 
 Architecture Support: all docker images, runtimes, tools are tested under x86_64 ONLY
 
 ### Default Peer Runtime selection
 
-When using Fabric 2.2/2.3x the default docker image that is used to run the Node chaincode is node:12.16.1-alpine. With Fabric 2.4 the default docker image is node:16.4.0-alpine
+* Fabric 2.2/2.3 `fabric-nodeenv` docker image is based on node:12.22.6-alpine.
+* Fabric 2.4 `fabric-nodeenv` docker image is based on node:16-alpine.
+* Fabric 2.5 `fabric-nodeenv` docker image is based on node:18-alpine.
 
 *Note:* With the default docker image used by Fabric 2.x, the packaged code will be installed with npm. If a `package-lock.json` or a `npm-shrinkwrap.json` file is present, `npm ci --only=production` will be used. Otherwise `npm install --production` will be used. 
 
-When using Fabric 1.4.4, the docker image that is used to run the Node chaincode is node v8.16.1. It is installed with npm install --production
+When using Fabric 1.4.x, the docker image that is used to run the Node.js chaincode is node v8.16.1. It is installed with npm install --production
 
 ### Supported Runtime communication with the Peer
 
-Subject to a suitable runtime environment, the 1.4.4 Node modules and 2.x Node modules can be used to communicate with a Fabric 2.x or 1.4.4 Peer - with the level of functionality that is implied by the Fabric version in use. 
+Subject to a suitable runtime environment, the 1.4.x Node.js chaincode modules and 2.x Node.js chaincode modules can be used to communicate with a Fabric 2.x or 1.4.x Peer - with the level of functionality that is implied by the Fabric version in use. 


### PR DESCRIPTION
Update COMPATIBILITY.md to indicate v2.5 uses Node.js 18. Other cleanup is also included.