### PR TITLE
TUTORIAL.md: fix missing quote in package.json template

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -19,7 +19,7 @@ The dependencies of `fabric-contract-api` and `fabric-shim` will be required.
     "npm": "^6.4.1"
   },
   "scripts": {
-    "test":"mocha.....
+    "test": "mocha....."
   },
   "engine-strict": true,
   "engineStrict": true,


### PR DESCRIPTION
This very modest contribution corrects a small typo in the example file that is intended to be copied by the reader of the tutorial.