### PR TITLE
Run vulnerability scan on latest release version

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,9 +17,12 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
 
+  scan:
+    uses: ./.github/workflows/scan.yaml
+
   pull-request:
     needs: test
     name: Pull request success
     runs-on: ubuntu-latest
     steps:
-      - run: 'true'
+      - run: "true"

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -1,0 +1,43 @@
+name: "Security vulnerability scan"
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Branch, tag or SHA to scan.
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  # Job to handle the auditing of the code
+  # NPM audit is run on a 'fake' installation of the libraries
+  # Pulling in all the dependencies it will be able to run NPM AUDIT, and if that returns a
+  # error code the job will fail.
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install
+        run: node common/scripts/install-run-rush.js install
+      - name: Build packages
+        run: node common/scripts/install-run-rush.js publish --include-all --pack --release-folder tgz --publish
+      - name: Start local NPM registry
+        run: node common/scripts/install-run-rush.js start-verdaccio # script will check for the ci variable and use built images
+      - name: Deploy scan project
+        run: |
+          mkdir -p audit
+          cd audit
+          npm init --yes
+          npm install --save --package-lock-only --registry http://localhost:4873 fabric-shim fabric-shim-api fabric-contract-api
+      - name: Scan
+        working-directory: audit
+        run: npm audit --omit=dev

--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -9,29 +9,18 @@ permissions:
   contents: read
 
 jobs:
-  # Job to handle the auditing of the code
-  # NPM audit is run on a 'fake' installation of the libraries
-  # Pulling in all the dependencies it will be able to run NPM AUDIT, and if that returns a
-  # error code the job will fail.
-  scan:
+  latest-release-version:
+    name: Get latest release tag
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag-name.outputs.value }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - name: Install
-        run: node common/scripts/install-run-rush.js install
-      - name: Build packages
-        run: node common/scripts/install-run-rush.js publish --include-all --pack --release-folder tgz --publish
-      - name: Start local NPM registry
-        run: node common/scripts/install-run-rush.js start-verdaccio # script will check for the ci variable and use built images
-      - name: Deploy scan project
-        run: |
-          mkdir -p audit
-          cd audit
-          npm init --yes
-          npm install --save --package-lock-only --registry http://localhost:4873 fabric-shim fabric-shim-api fabric-contract-api
-      - name: Scan
-        working-directory: audit
-        run: npm audit --omit=dev
+      - id: tag-name
+        run: echo "value=$(curl --location --silent --fail "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq --raw-output '.tag_name')" >> "${GITHUB_OUTPUT}"
+
+  scan:
+    name: Scan ${{ needs.latest-release-version.outputs.tag_name }}
+    needs: latest-release-version
+    uses: ./.github/workflows/scan.yaml
+    with:
+      ref: ${{ needs.latest-release-version.outputs.tag_name }}


### PR DESCRIPTION
Previously the scan ran on the current state of the codebase. This fails to identify vulnerabilities in dependencies for the latest release version if those dependencies have already been updated in the development codebase. The gating factor for whether a new release is required should be whether the previous release contains vulnerabilities.

This change runs the scheduled vulnerability scan on the latest release tag. It also adds vulnerability scanning to pull request builds. This is purely informational. A scan failure does not fail the pull request build.