### PR TITLE
Use public Fabric Docker images

### DIFF
--- a/tools/getEdgeDocker.sh
+++ b/tools/getEdgeDocker.sh
@@ -7,16 +7,15 @@
 set -euo pipefail
 
 version=${FABRIC_VERSION:-2.5}
-artifactory_url=hyperledger-fabric.jfrog.io
+docker_registry=docker.io
 
-for image in peer orderer ca baseos ccenv tools; do
-    artifactory_image="${artifactory_url}/fabric-${image}:amd64-${version}-stable"
-    docker pull -q "${artifactory_image}"
-    docker tag "${artifactory_image}" "hyperledger/fabric-${image}"
-    docker rmi -f "${artifactory_image}" >/dev/null
+for image in peer orderer baseos ccenv tools; do
+    image_name="hyperledger/fabric-${image}"
+    image_pull="${docker_registry}/${image_name}:${version}"
+    docker pull -q "${image_pull}"
+    docker tag "${image_pull}" "${image_name}"
 done
 
-docker pull -q couchdb:3.1
-docker pull -q hyperledger/fabric-ca:1.5.5
-docker tag hyperledger/fabric-ca:1.5.5 hyperledger/fabric-ca
-docker rmi hyperledger/fabric-ca:1.5.5 >/dev/null
+docker pull -q couchdb:latest
+docker pull -q "${docker_registry}/hyperledger/fabric-ca:1.5"
+docker tag "${docker_registry}/hyperledger/fabric-ca:1.5" hyperledger/fabric-ca

--- a/tools/toolchain/network/docker-compose/docker-compose-base.yaml
+++ b/tools/toolchain/network/docker-compose/docker-compose-base.yaml
@@ -11,11 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: '2'
 
 services:
   ca0:
-    image: hyperledger/fabric-ca${CA_IMG_TAG}
+    image: hyperledger/fabric-ca
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org1
@@ -29,7 +28,7 @@ services:
     container_name: ca_peerOrg1
 
   ca1:
-    image: hyperledger/fabric-ca${CA_IMG_TAG}
+    image: hyperledger/fabric-ca
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org2
@@ -58,10 +57,10 @@ services:
     ports:
       - 7050:7050
     volumes:
-        - ../crypto-material/:/etc/hyperledger/configtx
-        - ../crypto-material/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/:/etc/hyperledger/orderer
-        - ../crypto-material/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/peerOrg1
-        - ../crypto-material/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/:/etc/hyperledger/peerOrg2
+      - ../crypto-material/:/etc/hyperledger/configtx
+      - ../crypto-material/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/:/etc/hyperledger/orderer
+      - ../crypto-material/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/peerOrg1
+      - ../crypto-material/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/:/etc/hyperledger/peerOrg2
 
   peer:
     container_name: peer
@@ -101,9 +100,9 @@ services:
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     command: peer node start --peer-chaincodedev=true
     volumes:
-        - /var/run/:/host/var/run/
-        - ../external:/opt/chaincode/bin:ro
-        - ../crypto-material/core.yaml:/etc/hyperledger/fabric/core.yaml:ro
+      - /var/run/:/host/var/run/
+      - ../external:/opt/chaincode/bin:ro
+      - ../crypto-material/core.yaml:/etc/hyperledger/fabric/core.yaml:ro
 
   clibase:
     extends:
@@ -132,7 +131,7 @@ services:
 
   couchdb:
     container_name: couchdb
-    image: couchdb:3.1
+    image: couchdb
     environment:
       - COUCHDB_USER=admin
       - COUCHDB_PASSWORD=adminpw

--- a/tools/toolchain/network/docker-compose/docker-compose-cli.yaml
+++ b/tools/toolchain/network/docker-compose/docker-compose-cli.yaml
@@ -12,8 +12,6 @@
 # limitations under the License.
 #
 
-version: '2'
-
 services:
   clinopeer:
     container_name: cli

--- a/tools/toolchain/network/docker-compose/docker-compose-tls.yaml
+++ b/tools/toolchain/network/docker-compose/docker-compose-tls.yaml
@@ -11,14 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: '2'
 
 services:
-
   ca0.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: ca0
+      file: docker-compose-base.yaml
+      service: ca0
     container_name: ca0.example.com
     environment:
       - FABRIC_CA_SERVER_TLS_ENABLED=true
@@ -27,8 +25,8 @@ services:
 
   ca1.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: ca1
+      file: docker-compose-base.yaml
+      service: ca1
     container_name: ca1.example.com
     environment:
       - FABRIC_CA_SERVER_TLS_ENABLED=true
@@ -37,8 +35,8 @@ services:
 
   orderer.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: orderer
+      file: docker-compose-base.yaml
+      service: orderer
     container_name: orderer.example.com
     environment:
       - ORDERER_GENERAL_TLS_ENABLED=true
@@ -49,8 +47,8 @@ services:
 
   peer0.org1.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: peer
+      file: docker-compose-base.yaml
+      service: peer
     container_name: peer0.org1.example.com
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
@@ -74,16 +72,16 @@ services:
     ports:
       - 7051:7051
     volumes:
-        - /var/run/:/host/var/run/
-        - ../crypto-material/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/peer
+      - /var/run/:/host/var/run/
+      - ../crypto-material/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/peer
     depends_on:
       - orderer.example.com
       - couchdb.org1.example.com
 
   couchdb.org1.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: couchdb
+      file: docker-compose-base.yaml
+      service: couchdb
     container_name: couchdb.org1.example.com
     ports:
       - 5984:5984
@@ -92,8 +90,8 @@ services:
 
   peer0.org2.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: peer
+      file: docker-compose-base.yaml
+      service: peer
     container_name: peer0.org2.example.com
 
     environment:
@@ -118,16 +116,16 @@ services:
     ports:
       - 8051:8051
     volumes:
-        - /var/run/:/host/var/run/
-        - ../crypto-material/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/:/etc/hyperledger/peer
+      - /var/run/:/host/var/run/
+      - ../crypto-material/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/:/etc/hyperledger/peer
     depends_on:
       - orderer.example.com
       - couchdb.org2.example.com
 
   couchdb.org2.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: couchdb
+      file: docker-compose-base.yaml
+      service: couchdb
     container_name: couchdb.org2.example.com
     ports:
       - 6984:5984
@@ -154,7 +152,7 @@ services:
       - /var/run/:/host/var/run/
     depends_on:
       - peer0.org1.example.com
-      
+
   org2_cli:
     extends:
       file: docker-compose-base.yaml
@@ -183,4 +181,4 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./logs:/logs
     ports:
-    - 17056:80
+      - 17056:80

--- a/tools/toolchain/network/docker-compose/docker-compose.yaml
+++ b/tools/toolchain/network/docker-compose/docker-compose.yaml
@@ -11,32 +11,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: '2'
 
 services:
-
   ca0.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: ca0
+      file: docker-compose-base.yaml
+      service: ca0
     container_name: ca0.example.com
 
   ca1.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: ca1
+      file: docker-compose-base.yaml
+      service: ca1
     container_name: ca1.example.com
 
   orderer.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: orderer
+      file: docker-compose-base.yaml
+      service: orderer
     container_name: orderer.example.com
 
   peer0.org1.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: peer
+      file: docker-compose-base.yaml
+      service: peer
     container_name: peer0.org1.example.com
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
@@ -54,16 +52,16 @@ services:
     ports:
       - 7051:7051
     volumes:
-        - /var/run/:/host/var/run/
-        - ../crypto-material/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/peer
+      - /var/run/:/host/var/run/
+      - ../crypto-material/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/peer
     depends_on:
       - orderer.example.com
       - couchdb.org1.example.com
 
   couchdb.org1.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: couchdb
+      file: docker-compose-base.yaml
+      service: couchdb
     container_name: couchdb.org1.example.com
     ports:
       - 5984:5984
@@ -72,8 +70,8 @@ services:
 
   peer0.org2.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: peer
+      file: docker-compose-base.yaml
+      service: peer
     container_name: peer0.org2.example.com
 
     environment:
@@ -91,16 +89,16 @@ services:
     ports:
       - 8051:8051
     volumes:
-        - /var/run/:/host/var/run/
-        - ../crypto-material/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com:/etc/hyperledger/peer
+      - /var/run/:/host/var/run/
+      - ../crypto-material/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com:/etc/hyperledger/peer
     depends_on:
       - orderer.example.com
       - couchdb.org2.example.com
 
   couchdb.org2.example.com:
     extends:
-        file: docker-compose-base.yaml
-        service: couchdb
+      file: docker-compose-base.yaml
+      service: couchdb
     container_name: couchdb.org2.example.com
     ports:
       - 6984:5984
@@ -123,7 +121,7 @@ services:
       - /var/run/:/host/var/run/
     depends_on:
       - peer0.org1.example.com
-      
+
   org2_cli:
     extends:
       file: docker-compose-base.yaml
@@ -140,7 +138,7 @@ services:
       - /var/run/:/host/var/run/
     depends_on:
       - peer0.org2.example.com
-      
+
   logging:
     container_name: logging
     image: gliderlabs/logspout
@@ -148,4 +146,4 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./logs:/logs
     ports:
-    - 17056:80         
+      - 17056:80


### PR DESCRIPTION
The images in Hyperledger Artifactory are no longer updated and are well over a year old. This change uses the public Docker images from Docker Hub.