### PR TITLE
Reduce scheduled build frequency

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -5,7 +5,7 @@ name: Scheduled build
 
 on:
   schedule:
-    - cron: "5 2 * * *"
+    - cron: "5 2 * * 6"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The rate of change in this repository is low. Reduce scheduled build frequency to weekly to save build resources.